### PR TITLE
Implement animated idle for boxers

### DIFF
--- a/src/scripts/game-scene.js
+++ b/src/scripts/game-scene.js
@@ -9,11 +9,16 @@ export class GameScene extends Phaser.Scene {
     // add ring background
     this.add.image(400, 300, 'ring');
 
-    // define animations for boxer1
+    // create idle animation frames shared by both boxers
+    const idleFrames = [];
+    for (let i = 0; i < 10; i++) {
+      const frame = i.toString().padStart(3, '0');
+      idleFrames.push({ key: `idle_${frame}` });
+    }
     this.anims.create({
       key: 'boxer1_idle',
-      frames: [{ key: 'boxer1', frame: 0 }],
-      frameRate: 1,
+      frames: idleFrames,
+      frameRate: 10,
       repeat: -1
     });
     this.anims.create({
@@ -26,8 +31,8 @@ export class GameScene extends Phaser.Scene {
     // define animations for boxer2
     this.anims.create({
       key: 'boxer2_idle',
-      frames: [{ key: 'boxer2', frame: 0 }],
-      frameRate: 1,
+      frames: idleFrames,
+      frameRate: 10,
       repeat: -1
     });
     this.anims.create({
@@ -37,9 +42,13 @@ export class GameScene extends Phaser.Scene {
       repeat: 0
     });
 
-    // create sprites
-    this.player1 = this.add.sprite(200, 400, 'boxer1').play('boxer1_idle');
-    this.player2 = this.add.sprite(600, 400, 'boxer2').play('boxer2_idle');
+    // create sprites using the new idle frames
+    this.player1 = this.add.sprite(200, 400, 'idle_000').play('boxer1_idle');
+    this.player1.setScale(400 / this.player1.height);
+    this.player1.setFlipX(true);
+
+    this.player2 = this.add.sprite(600, 400, 'idle_000').play('boxer2_idle');
+    this.player2.setScale(400 / this.player2.height);
 
     // input: arrows for player1, WASD for player2
     this.cursors = this.input.keyboard.createCursorKeys();
@@ -99,16 +108,29 @@ export class GameScene extends Phaser.Scene {
     }
 
     // === BOUNDARIES ===
-    const halfW = 32; // half of frameWidth
-    const halfH = 32; // half of frameHeight
-    const minX = halfW;
-    const maxX = this.sys.game.config.width - halfW;
-    const minY = halfH;
-    const maxY = this.sys.game.config.height - halfH;
+    const width = this.sys.game.config.width;
+    const height = this.sys.game.config.height;
 
-    this.player1.x = Phaser.Math.Clamp(this.player1.x, minX, maxX);
-    this.player1.y = Phaser.Math.Clamp(this.player1.y, minY, maxY);
-    this.player2.x = Phaser.Math.Clamp(this.player2.x, minX, maxX);
-    this.player2.y = Phaser.Math.Clamp(this.player2.y, minY, maxY);
+    this.player1.x = Phaser.Math.Clamp(
+      this.player1.x,
+      this.player1.displayWidth / 2,
+      width - this.player1.displayWidth / 2
+    );
+    this.player1.y = Phaser.Math.Clamp(
+      this.player1.y,
+      this.player1.displayHeight / 2,
+      height - this.player1.displayHeight / 2
+    );
+
+    this.player2.x = Phaser.Math.Clamp(
+      this.player2.x,
+      this.player2.displayWidth / 2,
+      width - this.player2.displayWidth / 2
+    );
+    this.player2.y = Phaser.Math.Clamp(
+      this.player2.y,
+      this.player2.displayHeight / 2,
+      height - this.player2.displayHeight / 2
+    );
   }
 }

--- a/src/scripts/main.js
+++ b/src/scripts/main.js
@@ -9,6 +9,11 @@ class BootScene extends Phaser.Scene {
   preload() {
     console.log('BootScene: preload started');
     this.load.image('ring', 'assets/ring.png');
+    // Load idle animation frames for the boxers
+    for (let i = 0; i < 10; i++) {
+      const frame = i.toString().padStart(3, '0');
+      this.load.image(`idle_${frame}`, `assets/1-Idle/__Boxer2_Idle_${frame}.png`);
+    }
     this.load.spritesheet('boxer1', 'assets/boxer1.png', {
       frameWidth: 64,
       frameHeight: 64


### PR DESCRIPTION
## Summary
- add loading of high-res idle frames
- create idle animations from the new frames
- scale sprites to 400px tall and flip player1 horizontally
- clamp players based on their display size

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_6888af3ce124832aad49ac1534caf9f8