### PR TITLE
Implement blocker animation

### DIFF
--- a/src/scripts/game-scene.js
+++ b/src/scripts/game-scene.js
@@ -18,10 +18,12 @@ export class GameScene extends Phaser.Scene {
     // walk animation frames
     const forwardFrames = [];
     const backwardFrames = [];
+    const blockFrames = [];
     for (let i = 0; i < 10; i++) {
       const frame = i.toString().padStart(3, '0');
       forwardFrames.push({ key: `forward_${frame}` });
       backwardFrames.push({ key: `backward_${frame}` });
+      blockFrames.push({ key: `block_${frame}` });
     }
     this.anims.create({
       key: 'boxer1_idle',
@@ -44,6 +46,12 @@ export class GameScene extends Phaser.Scene {
     this.anims.create({
       key: 'boxer1_backward',
       frames: backwardFrames,
+      frameRate: 10,
+      repeat: -1
+    });
+    this.anims.create({
+      key: 'boxer1_block',
+      frames: blockFrames,
       frameRate: 10,
       repeat: -1
     });
@@ -73,6 +81,12 @@ export class GameScene extends Phaser.Scene {
       frameRate: 10,
       repeat: -1
     });
+    this.anims.create({
+      key: 'boxer2_block',
+      frames: blockFrames,
+      frameRate: 10,
+      repeat: -1
+    });
 
     // create sprites using the new idle frames
     this.player1 = this.add.sprite(200, 400, 'idle_000').play('boxer1_idle');
@@ -91,6 +105,13 @@ export class GameScene extends Phaser.Scene {
       right: Phaser.Input.Keyboard.KeyCodes.D,
       punch2: Phaser.Input.Keyboard.KeyCodes.SHIFT
     });
+    // block keys
+    this.blockKey1 = this.input.keyboard.addKey(
+      Phaser.Input.Keyboard.KeyCodes.X
+    );
+    this.blockKey2 = this.input.keyboard.addKey(
+      Phaser.Input.Keyboard.KeyCodes.FIVE
+    );
 
     // punch events
     this.input.keyboard.on('keydown-SPACE', () => {
@@ -120,7 +141,9 @@ export class GameScene extends Phaser.Scene {
       ? this.player1.anims.currentAnim.key
       : '';
     if (p1Anim !== 'boxer1_punch') {
-      if (this.cursors.left.isDown) {
+      if (this.blockKey1.isDown) {
+        this.player1.anims.play('boxer1_block', true);
+      } else if (this.cursors.left.isDown) {
         this.player1.x -= move;
         this.player1.anims.play('boxer1_backward', true);
       } else if (this.cursors.right.isDown) {
@@ -141,7 +164,9 @@ export class GameScene extends Phaser.Scene {
       ? this.player2.anims.currentAnim.key
       : '';
     if (p2Anim !== 'boxer2_punch') {
-      if (this.WASD.left.isDown) {
+      if (this.blockKey2.isDown) {
+        this.player2.anims.play('boxer2_block', true);
+      } else if (this.WASD.left.isDown) {
         this.player2.x -= move;
         this.player2.anims.play('boxer2_forward', true);
       } else if (this.WASD.right.isDown) {

--- a/src/scripts/main.js
+++ b/src/scripts/main.js
@@ -12,9 +12,22 @@ class BootScene extends Phaser.Scene {
     // Load idle animation frames for the boxers
     for (let i = 0; i < 10; i++) {
       const frame = i.toString().padStart(3, '0');
-      this.load.image(`idle_${frame}`, `assets/1-Idle/__Boxer2_Idle_${frame}.png`);
-      this.load.image(`forward_${frame}`, `assets/2-Walk/1-Forward/__Boxer2_Forward_${frame}.png`);
-      this.load.image(`backward_${frame}`, `assets/2-Walk/2-Backward/__Boxer2_Backward_${frame}.png`);
+      this.load.image(
+        `idle_${frame}`,
+        `assets/1-Idle/__Boxer2_Idle_${frame}.png`
+      );
+      this.load.image(
+        `forward_${frame}`,
+        `assets/2-Walk/1-Forward/__Boxer2_Forward_${frame}.png`
+      );
+      this.load.image(
+        `backward_${frame}`,
+        `assets/2-Walk/2-Backward/__Boxer2_Backward_${frame}.png`
+      );
+      this.load.image(
+        `block_${frame}`,
+        `assets/4-Block/__Boxer2_Block_${frame}.png`
+      );
     }
     this.load.spritesheet('boxer1', 'assets/boxer1.png', {
       frameWidth: 64,


### PR DESCRIPTION
## Summary
- load block sprite frames
- add block animations and input keys
- allow holding keys to keep a boxer blocking

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6889c503a9dc832aac1b46add9aca827