### PR TITLE
Fix KO animation to not loop

### DIFF
--- a/src/scripts/game-scene.js
+++ b/src/scripts/game-scene.js
@@ -112,7 +112,7 @@ export class GameScene extends Phaser.Scene {
       key: 'boxer1_ko',
       frames: koFrames,
       frameRate: 10,
-      repeat: -1
+      repeat: 0
     });
 
     // define animations for boxer2
@@ -186,7 +186,7 @@ export class GameScene extends Phaser.Scene {
       key: 'boxer2_ko',
       frames: koFrames,
       frameRate: 10,
-      repeat: -1
+      repeat: 0
     });
 
     // create sprites using the new idle frames


### PR DESCRIPTION
## Summary
- adjust KO animations for both players so they only play once

## Testing
- `grep -n "boxer._ko" -n src/scripts/game-scene.js`

------
https://chatgpt.com/codex/tasks/task_e_6889dcbb0bd0832a8feda19b52db6795