### PR TITLE
Enable turning and tint boxer2

### DIFF
--- a/src/scripts/boxer.js
+++ b/src/scripts/boxer.js
@@ -8,12 +8,22 @@ export class Boxer {
     this.speed = 200;
     this.sprite.setScale(400 / this.sprite.height);
     // boxer1 faces right, boxer2 faces left
-    if (prefix === 'boxer1') this.sprite.setFlipX(true);
+    this.facingRight = prefix === 'boxer1';
+    this.sprite.setFlipX(this.facingRight);
+    if (prefix === 'boxer2') this.sprite.setTint(0xbb7744);
   }
 
   update(delta) {
     const move = (this.speed * delta) / 1000;
     const actions = this.controller.getActions();
+
+    if (actions.turnLeft) {
+      this.facingRight = false;
+      this.sprite.setFlipX(false);
+    } else if (actions.turnRight) {
+      this.facingRight = true;
+      this.sprite.setFlipX(true);
+    }
 
     if (actions.block) {
       this.sprite.anims.play(`${this.prefix}_block`, true);
@@ -25,11 +35,11 @@ export class Boxer {
       this.playOnce(`${this.prefix}_uppercut`);
     } else if (actions.moveLeft) {
       this.sprite.x -= move;
-      const anim = this.prefix === 'boxer1' ? 'backward' : 'forward';
+      const anim = this.facingRight ? 'backward' : 'forward';
       this.sprite.anims.play(`${this.prefix}_${anim}`, true);
     } else if (actions.moveRight) {
       this.sprite.x += move;
-      const anim = this.prefix === 'boxer1' ? 'forward' : 'backward';
+      const anim = this.facingRight ? 'forward' : 'backward';
       this.sprite.anims.play(`${this.prefix}_${anim}`, true);
     } else {
       this.sprite.anims.play(`${this.prefix}_idle`, true);

--- a/src/scripts/controllers.js
+++ b/src/scripts/controllers.js
@@ -5,15 +5,21 @@ export class KeyboardController {
   }
 
   getActions() {
+    const shift = this.cursors.shift.isDown;
+    const leftKey = this.keys.left || this.cursors.left;
+    const rightKey = this.keys.right || this.cursors.right;
+
     return {
-      moveLeft: this.cursors.left.isDown || this.keys.left?.isDown,
-      moveRight: this.cursors.right.isDown || this.keys.right?.isDown,
+      moveLeft: leftKey.isDown && !shift,
+      moveRight: rightKey.isDown && !shift,
       moveUp: this.cursors.up.isDown || this.keys.up?.isDown,
       moveDown: this.cursors.down.isDown || this.keys.down?.isDown,
       block: this.keys.block?.isDown,
       jabRight: Phaser.Input.Keyboard.JustDown(this.keys.jabRight),
       jabLeft: Phaser.Input.Keyboard.JustDown(this.keys.jabLeft),
       uppercut: Phaser.Input.Keyboard.JustDown(this.keys.uppercut),
+      turnLeft: shift && Phaser.Input.Keyboard.JustDown(leftKey),
+      turnRight: shift && Phaser.Input.Keyboard.JustDown(rightKey),
     };
   }
 }
@@ -37,6 +43,8 @@ export class RandomAIController {
         jabRight: Math.random() < 0.05,
         jabLeft: Math.random() < 0.05,
         uppercut: Math.random() < 0.02,
+        turnLeft: false,
+        turnRight: false,
       };
       this.current = actions;
     }


### PR DESCRIPTION
## Summary
- add ability to turn by holding SHIFT with a direction key
- tint boxer2 to visually differentiate
- adjust movement animations to respect current facing

## Testing
- `node -e "import('./src/scripts/controllers.js').then(()=>console.log('ok')).catch(e=>console.error(e))"`
- `node -e "import('./src/scripts/boxer.js').then(()=>console.log('ok')).catch(e=>console.error(e))"`
- `node -e "import('./src/scripts/game-scene.js').then(()=>console.log('ok')).catch(e=>console.error(e))"` *(fails: Phaser is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_6889e5b9a8dc832ab939523c5fee2b2f