### PR TITLE
Fix hurt/KO controls and dual keyboard support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # The Boxer
 
 A small boxing game built with Phaser. Two boxers are displayed in the ring.
-The code is structured so that each boxer is controlled by a controller
-object. The default setup uses a keyboard controller for the first boxer and
-an automated random controller for the second boxer. This structure makes it
-simple to plug in different AI or input strategies for simulations.
+Each boxer is controlled by a controller object. The current setup uses a
+keyboard controller for both boxers so you can play locally with two sets of
+keys. Because the behaviour is abstracted through controllers it is trivial to
+swap a boxer to a programmatic or AI driven controller in the future.

--- a/src/scripts/boxer.js
+++ b/src/scripts/boxer.js
@@ -16,6 +16,13 @@ export class Boxer {
   update(delta) {
     const move = (this.speed * delta) / 1000;
     const actions = this.controller.getActions();
+    const current = this.sprite.anims.currentAnim?.key || '';
+    const hurtingStates = [
+      `${this.prefix}_hurt1`,
+      `${this.prefix}_hurt2`,
+      `${this.prefix}_dizzy`,
+      `${this.prefix}_ko`,
+    ];
 
     if (actions.turnLeft) {
       this.facingRight = false;
@@ -23,6 +30,30 @@ export class Boxer {
     } else if (actions.turnRight) {
       this.facingRight = true;
       this.sprite.setFlipX(true);
+    }
+
+    if (actions.ko) {
+      this.sprite.play(`${this.prefix}_ko`);
+      return;
+    }
+    if (actions.hurt1) {
+      this.sprite.anims.play(`${this.prefix}_hurt1`, true);
+      return;
+    }
+    if (actions.hurt2) {
+      this.sprite.anims.play(`${this.prefix}_hurt2`, true);
+      return;
+    }
+    if (actions.dizzy) {
+      this.sprite.anims.play(`${this.prefix}_dizzy`, true);
+      return;
+    }
+    if (actions.idle) {
+      this.sprite.anims.play(`${this.prefix}_idle`, true);
+      return;
+    }
+    if (hurtingStates.includes(current)) {
+      return;
     }
 
     if (actions.block) {

--- a/src/scripts/controllers.js
+++ b/src/scripts/controllers.js
@@ -20,6 +20,11 @@ export class KeyboardController {
       uppercut: Phaser.Input.Keyboard.JustDown(this.keys.uppercut),
       turnLeft: shift && Phaser.Input.Keyboard.JustDown(leftKey),
       turnRight: shift && Phaser.Input.Keyboard.JustDown(rightKey),
+      hurt1: Phaser.Input.Keyboard.JustDown(this.keys.hurt1),
+      hurt2: Phaser.Input.Keyboard.JustDown(this.keys.hurt2),
+      dizzy: Phaser.Input.Keyboard.JustDown(this.keys.dizzy),
+      idle: Phaser.Input.Keyboard.JustDown(this.keys.idle),
+      ko: Phaser.Input.Keyboard.JustDown(this.keys.ko),
     };
   }
 }
@@ -45,6 +50,11 @@ export class RandomAIController {
         uppercut: Math.random() < 0.02,
         turnLeft: false,
         turnRight: false,
+        hurt1: false,
+        hurt2: false,
+        dizzy: false,
+        idle: false,
+        ko: false,
       };
       this.current = actions;
     }

--- a/src/scripts/game-scene.js
+++ b/src/scripts/game-scene.js
@@ -1,5 +1,5 @@
 import { Boxer } from './boxer.js';
-import { KeyboardController, RandomAIController } from './controllers.js';
+import { KeyboardController } from './controllers.js';
 
 export class GameScene extends Phaser.Scene {
   constructor() {
@@ -198,8 +198,27 @@ export class GameScene extends Phaser.Scene {
       jabLeft: Phaser.Input.Keyboard.KeyCodes.DELETE,
       uppercut: Phaser.Input.Keyboard.KeyCodes.NUMPAD_ZERO,
       block: Phaser.Input.Keyboard.KeyCodes.NUMPAD_FIVE,
+      hurt1: Phaser.Input.Keyboard.KeyCodes.ONE,
+      hurt2: Phaser.Input.Keyboard.KeyCodes.TWO,
+      dizzy: Phaser.Input.Keyboard.KeyCodes.THREE,
+      idle: Phaser.Input.Keyboard.KeyCodes.SEVEN,
+      ko: Phaser.Input.Keyboard.KeyCodes.NUMPAD_EIGHT,
     });
-    const controller2 = new RandomAIController();
+    const controller2 = new KeyboardController(this, {
+      left: Phaser.Input.Keyboard.KeyCodes.A,
+      right: Phaser.Input.Keyboard.KeyCodes.D,
+      up: Phaser.Input.Keyboard.KeyCodes.W,
+      down: Phaser.Input.Keyboard.KeyCodes.S,
+      jabRight: Phaser.Input.Keyboard.KeyCodes.E,
+      jabLeft: Phaser.Input.Keyboard.KeyCodes.Q,
+      uppercut: Phaser.Input.Keyboard.KeyCodes.F,
+      block: Phaser.Input.Keyboard.KeyCodes.X,
+      hurt1: Phaser.Input.Keyboard.KeyCodes.FOUR,
+      hurt2: Phaser.Input.Keyboard.KeyCodes.FIVE,
+      dizzy: Phaser.Input.Keyboard.KeyCodes.SIX,
+      idle: Phaser.Input.Keyboard.KeyCodes.EIGHT,
+      ko: Phaser.Input.Keyboard.KeyCodes.G,
+    });
 
     this.player1 = new Boxer(this, 200, 400, 'boxer1', controller1);
     this.player2 = new Boxer(this, 600, 400, 'boxer2', controller2);


### PR DESCRIPTION
## Summary
- add keyboard actions for hurt, KO, and idle
- support these animations in `Boxer`
- use keyboard controllers for both boxers
- update README

## Testing
- `node --version`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6889efdb307c832a89ea5e2bb9f4efe8