### PR TITLE
Add boxer win mode

### DIFF
--- a/src/scripts/boxer.js
+++ b/src/scripts/boxer.js
@@ -22,6 +22,7 @@ export class Boxer {
       `${this.prefix}_hurt2`,
       `${this.prefix}_dizzy`,
       `${this.prefix}_ko`,
+      `${this.prefix}_win`,
     ];
 
     if (actions.turnLeft) {
@@ -46,6 +47,10 @@ export class Boxer {
     }
     if (actions.dizzy) {
       this.sprite.anims.play(`${this.prefix}_dizzy`, true);
+      return;
+    }
+    if (actions.win) {
+      this.sprite.anims.play(`${this.prefix}_win`, true);
       return;
     }
     if (actions.idle) {

--- a/src/scripts/controllers.js
+++ b/src/scripts/controllers.js
@@ -25,6 +25,7 @@ export class KeyboardController {
       dizzy: Phaser.Input.Keyboard.JustDown(this.keys.dizzy),
       idle: Phaser.Input.Keyboard.JustDown(this.keys.idle),
       ko: Phaser.Input.Keyboard.JustDown(this.keys.ko),
+      win: Phaser.Input.Keyboard.JustDown(this.keys.win),
     };
   }
 }

--- a/src/scripts/game-scene.js
+++ b/src/scripts/game-scene.js
@@ -29,6 +29,7 @@ export class GameScene extends Phaser.Scene {
     const hurt2Frames = [];
     const dizzyFrames = [];
     const koFrames = [];
+    const winFrames = [];
     for (let i = 0; i < 10; i++) {
       const frame = i.toString().padStart(3, '0');
       forwardFrames.push({ key: `forward_${frame}` });
@@ -44,6 +45,10 @@ export class GameScene extends Phaser.Scene {
       hurt2Frames.push({ key: `hurt2_${frame}` });
       dizzyFrames.push({ key: `dizzy_${frame}` });
       koFrames.push({ key: `ko_${frame}` });
+    }
+    for (let i = 0; i < 4; i++) {
+      const frame = i.toString().padStart(3, '0');
+      winFrames.push({ key: `win_${frame}` });
     }
     this.anims.create({
       key: 'boxer1_idle',
@@ -116,6 +121,12 @@ export class GameScene extends Phaser.Scene {
       frames: koFrames,
       frameRate: 10,
       repeat: 0
+    });
+    this.anims.create({
+      key: 'boxer1_win',
+      frames: winFrames,
+      frameRate: 10,
+      repeat: -1
     });
 
     // define animations for boxer2
@@ -191,6 +202,12 @@ export class GameScene extends Phaser.Scene {
       frameRate: 10,
       repeat: 0
     });
+    this.anims.create({
+      key: 'boxer2_win',
+      frames: winFrames,
+      frameRate: 10,
+      repeat: -1
+    });
 
     // controllers
     const controller1 = new KeyboardController(this, {
@@ -203,6 +220,7 @@ export class GameScene extends Phaser.Scene {
       dizzy: Phaser.Input.Keyboard.KeyCodes.THREE,
       idle: Phaser.Input.Keyboard.KeyCodes.SEVEN,
       ko: Phaser.Input.Keyboard.KeyCodes.NUMPAD_EIGHT,
+      win: Phaser.Input.Keyboard.KeyCodes.ZERO,
     });
     const controller2 = new KeyboardController(this, {
       left: Phaser.Input.Keyboard.KeyCodes.A,
@@ -218,6 +236,7 @@ export class GameScene extends Phaser.Scene {
       dizzy: Phaser.Input.Keyboard.KeyCodes.SIX,
       idle: Phaser.Input.Keyboard.KeyCodes.EIGHT,
       ko: Phaser.Input.Keyboard.KeyCodes.G,
+      win: Phaser.Input.Keyboard.KeyCodes.PLUS,
     });
 
     this.player1 = new Boxer(this, 200, 400, 'boxer1', controller1);

--- a/src/scripts/main.js
+++ b/src/scripts/main.js
@@ -65,6 +65,14 @@ class BootScene extends Phaser.Scene {
         `assets/6-KO/__Boxer2_KO_${frame}.png`
       );
     }
+    // Load win animation frames (4 frames)
+    for (let i = 0; i < 4; i++) {
+      const frame = i.toString().padStart(3, '0');
+      this.load.image(
+        `win_${frame}`,
+        `assets/7-Win/__Boxer2_win_${frame}.png`
+      );
+    }
     this.load.spritesheet('boxer1', 'assets/boxer1.png', {
       frameWidth: 64,
       frameHeight: 64


### PR DESCRIPTION
## Summary
- preload win sprites
- create win animations in game scene
- allow triggering win with `0` and `+` keys
- keep boxers in win animation until another state is chosen

## Testing
- `node --version`

------
https://chatgpt.com/codex/tasks/task_e_688a12c8de44832a97acdad195d586de