### PR TITLE
Add movement during injuries and document controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,26 @@ Each boxer is controlled by a controller object. The current setup uses a
 keyboard controller for both boxers so you can play locally with two sets of
 keys. Because the behaviour is abstracted through controllers it is trivial to
 swap a boxer to a programmatic or AI driven controller in the future.
+
+## Keyboard Controls
+
+The table below lists the keys used to control each boxer.
+
+| Action | Player 1 | Player 2 |
+|-------|---------|---------|
+| Move left | Left Arrow | `A` |
+| Move right | Right Arrow | `D` |
+| Move up | Up Arrow | `W` |
+| Move down | Down Arrow | `S` |
+| Turn left | `Shift` + Left Arrow | `Shift` + `A` |
+| Turn right | `Shift` + Right Arrow | `Shift` + `D` |
+| Block | Numpad 5 | `X` |
+| Jab right | Page Down | `E` |
+| Jab left | Delete | `Q` |
+| Uppercut | Numpad 0 | `F` |
+| Hurt 1 | `1` | `4` |
+| Hurt 2 | `2` | `5` |
+| Dizzy | `3` | `6` |
+| Idle | `7` | `8` |
+| KO | Numpad 8 | `G` |
+| Win | `0` | `+` |

--- a/src/scripts/boxer.js
+++ b/src/scripts/boxer.js
@@ -17,10 +17,12 @@ export class Boxer {
     const move = (this.speed * delta) / 1000;
     const actions = this.controller.getActions();
     const current = this.sprite.anims.currentAnim?.key || '';
-    const hurtingStates = [
+    const injuredStates = [
       `${this.prefix}_hurt1`,
       `${this.prefix}_hurt2`,
       `${this.prefix}_dizzy`,
+    ];
+    const lockedStates = [
       `${this.prefix}_ko`,
       `${this.prefix}_win`,
     ];
@@ -37,48 +39,52 @@ export class Boxer {
       this.sprite.play(`${this.prefix}_ko`);
       return;
     }
-    if (actions.hurt1) {
-      this.sprite.anims.play(`${this.prefix}_hurt1`, true);
-      return;
-    }
-    if (actions.hurt2) {
-      this.sprite.anims.play(`${this.prefix}_hurt2`, true);
-      return;
-    }
-    if (actions.dizzy) {
-      this.sprite.anims.play(`${this.prefix}_dizzy`, true);
-      return;
-    }
     if (actions.win) {
       this.sprite.anims.play(`${this.prefix}_win`, true);
       return;
     }
-    if (actions.idle) {
+    if (actions.hurt1) {
+      this.sprite.anims.play(`${this.prefix}_hurt1`, true);
+    } else if (actions.hurt2) {
+      this.sprite.anims.play(`${this.prefix}_hurt2`, true);
+    } else if (actions.dizzy) {
+      this.sprite.anims.play(`${this.prefix}_dizzy`, true);
+    } else if (actions.idle) {
       this.sprite.anims.play(`${this.prefix}_idle`, true);
-      return;
     }
-    if (hurtingStates.includes(current)) {
+
+    if (lockedStates.includes(current)) {
       return;
     }
 
-    if (actions.block) {
-      this.sprite.anims.play(`${this.prefix}_block`, true);
-    } else if (actions.jabRight) {
-      this.playOnce(`${this.prefix}_jabRight`);
-    } else if (actions.jabLeft) {
-      this.playOnce(`${this.prefix}_jabLeft`);
-    } else if (actions.uppercut) {
-      this.playOnce(`${this.prefix}_uppercut`);
-    } else if (actions.moveLeft) {
-      this.sprite.x -= move;
-      const anim = this.facingRight ? 'backward' : 'forward';
-      this.sprite.anims.play(`${this.prefix}_${anim}`, true);
-    } else if (actions.moveRight) {
-      this.sprite.x += move;
-      const anim = this.facingRight ? 'forward' : 'backward';
-      this.sprite.anims.play(`${this.prefix}_${anim}`, true);
+    const isInjured = injuredStates.includes(current);
+
+    if (!isInjured) {
+      if (actions.block) {
+        this.sprite.anims.play(`${this.prefix}_block`, true);
+      } else if (actions.jabRight) {
+        this.playOnce(`${this.prefix}_jabRight`);
+      } else if (actions.jabLeft) {
+        this.playOnce(`${this.prefix}_jabLeft`);
+      } else if (actions.uppercut) {
+        this.playOnce(`${this.prefix}_uppercut`);
+      } else if (actions.moveLeft) {
+        this.sprite.x -= move;
+        const anim = this.facingRight ? 'backward' : 'forward';
+        this.sprite.anims.play(`${this.prefix}_${anim}`, true);
+      } else if (actions.moveRight) {
+        this.sprite.x += move;
+        const anim = this.facingRight ? 'forward' : 'backward';
+        this.sprite.anims.play(`${this.prefix}_${anim}`, true);
+      } else {
+        this.sprite.anims.play(`${this.prefix}_idle`, true);
+      }
     } else {
-      this.sprite.anims.play(`${this.prefix}_idle`, true);
+      if (actions.moveLeft) {
+        this.sprite.x -= move;
+      } else if (actions.moveRight) {
+        this.sprite.x += move;
+      }
     }
 
     if (actions.moveUp) {


### PR DESCRIPTION
## Summary
- allow boxer movement while in hurt states
- keep KO and win states immobile
- document keyboard controls in README

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688a1571c7f8832a8d9eb3be56dea754