### PR TITLE
Fix boxer animations

### DIFF
--- a/src/scripts/boxer.js
+++ b/src/scripts/boxer.js
@@ -44,11 +44,11 @@ export class Boxer {
       return;
     }
     if (actions.hurt1) {
-      this.sprite.anims.play(`${this.prefix}_hurt1`, true);
+      this.playOnce(`${this.prefix}_hurt1`);
     } else if (actions.hurt2) {
-      this.sprite.anims.play(`${this.prefix}_hurt2`, true);
+      this.playOnce(`${this.prefix}_hurt2`);
     } else if (actions.dizzy) {
-      this.sprite.anims.play(`${this.prefix}_dizzy`, true);
+      this.playOnce(`${this.prefix}_dizzy`);
     } else if (actions.idle) {
       this.sprite.anims.play(`${this.prefix}_idle`, true);
     }

--- a/src/scripts/game-scene.js
+++ b/src/scripts/game-scene.js
@@ -43,8 +43,11 @@ export class GameScene extends Phaser.Scene {
       uppercutFrames.push({ key: `uppercut_${frame}` });
       hurt1Frames.push({ key: `hurt1_${frame}` });
       hurt2Frames.push({ key: `hurt2_${frame}` });
-      dizzyFrames.push({ key: `dizzy_${frame}` });
       koFrames.push({ key: `ko_${frame}` });
+    }
+    for (let i = 0; i < 10; i++) {
+      const frame = i.toString().padStart(3, '0');
+      dizzyFrames.push({ key: `dizzy_${frame}` });
     }
     for (let i = 0; i < 4; i++) {
       const frame = i.toString().padStart(3, '0');
@@ -102,19 +105,19 @@ export class GameScene extends Phaser.Scene {
       key: 'boxer1_hurt1',
       frames: hurt1Frames,
       frameRate: 10,
-      repeat: -1
+      repeat: 0
     });
     this.anims.create({
       key: 'boxer1_hurt2',
       frames: hurt2Frames,
       frameRate: 10,
-      repeat: -1
+      repeat: 0
     });
     this.anims.create({
       key: 'boxer1_dizzy',
       frames: dizzyFrames,
       frameRate: 10,
-      repeat: -1
+      repeat: 0
     });
     this.anims.create({
       key: 'boxer1_ko',
@@ -182,19 +185,19 @@ export class GameScene extends Phaser.Scene {
       key: 'boxer2_hurt1',
       frames: hurt1Frames,
       frameRate: 10,
-      repeat: -1
+      repeat: 0
     });
     this.anims.create({
       key: 'boxer2_hurt2',
       frames: hurt2Frames,
       frameRate: 10,
-      repeat: -1
+      repeat: 0
     });
     this.anims.create({
       key: 'boxer2_dizzy',
       frames: dizzyFrames,
       frameRate: 10,
-      repeat: -1
+      repeat: 0
     });
     this.anims.create({
       key: 'boxer2_ko',

--- a/src/scripts/main.js
+++ b/src/scripts/main.js
@@ -57,12 +57,16 @@ class BootScene extends Phaser.Scene {
         `assets/5-Hurt/2-HurtAlt/__Boxer2_Hurt2_${frame}.png`
       );
       this.load.image(
-        `dizzy_${frame}`,
-        `assets/5-Hurt/3-Dizzy/__Boxer2_Dizzy_${frame}.png`
-      );
-      this.load.image(
         `ko_${frame}`,
         `assets/6-KO/__Boxer2_KO_${frame}.png`
+      );
+    }
+    // Dizzy animation uses 10 frames
+    for (let i = 0; i < 10; i++) {
+      const frame = i.toString().padStart(3, '0');
+      this.load.image(
+        `dizzy_${frame}`,
+        `assets/5-Hurt/3-Dizzy/__Boxer2_Dizzy_${frame}.png`
       );
     }
     // Load win animation frames (4 frames)


### PR DESCRIPTION
## Summary
- ensure all dizzy frames are loaded
- generate 10 dizzy frames and stop repeating injury animations
- use playOnce for hurt and dizzy animations

## Testing
- `node --check src/scripts/boxer.js`
- `node --check src/scripts/main.js`
- `node --check src/scripts/game-scene.js`


------
https://chatgpt.com/codex/tasks/task_e_688a1e3dd834832a9f9248c9da98036e