### PR TITLE
Fix injured animation cancelling on movement

### DIFF
--- a/src/scripts/boxer.js
+++ b/src/scripts/boxer.js
@@ -16,7 +16,6 @@ export class Boxer {
   update(delta) {
     const move = (this.speed * delta) / 1000;
     const actions = this.controller.getActions();
-    const current = this.sprite.anims.currentAnim?.key || '';
     const injuredStates = [
       `${this.prefix}_hurt1`,
       `${this.prefix}_hurt2`,
@@ -52,6 +51,8 @@ export class Boxer {
     } else if (actions.idle) {
       this.sprite.anims.play(`${this.prefix}_idle`, true);
     }
+
+    const current = this.sprite.anims.currentAnim?.key || '';
 
     if (lockedStates.includes(current)) {
       return;


### PR DESCRIPTION
## Summary
- recompute current animation after applying hurt actions
- prevent movement logic from cancelling hurt animations

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688a25cbf0c4832a92ade4136c656d25