### PR TITLE
Fix attack animations

### DIFF
--- a/src/scripts/boxer.js
+++ b/src/scripts/boxer.js
@@ -21,6 +21,11 @@ export class Boxer {
       `${this.prefix}_hurt2`,
       `${this.prefix}_dizzy`,
     ];
+    const attackStates = [
+      `${this.prefix}_jabRight`,
+      `${this.prefix}_jabLeft`,
+      `${this.prefix}_uppercut`,
+    ];
     const lockedStates = [
       `${this.prefix}_ko`,
       `${this.prefix}_win`,
@@ -59,8 +64,9 @@ export class Boxer {
     }
 
     const isInjured = injuredStates.includes(current);
+    const isAttacking = attackStates.includes(current);
 
-    if (!isInjured) {
+    if (!isInjured && !isAttacking) {
       if (actions.block) {
         this.sprite.anims.play(`${this.prefix}_block`, true);
       } else if (actions.jabRight) {


### PR DESCRIPTION
## Summary
- keep attack animations playing until they finish

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688a61781fc8832aab5794708a546a9f