### PR TITLE
Introduce simple collision and health logic

### DIFF
--- a/src/scripts/boxer.js
+++ b/src/scripts/boxer.js
@@ -11,6 +11,8 @@ export class Boxer {
     this.facingRight = prefix === 'boxer1';
     this.sprite.setFlipX(this.facingRight);
     if (prefix === 'boxer2') this.sprite.setTint(0xbb7744);
+    this.health = 1;
+    this.hasHit = false;
   }
 
   update(delta) {
@@ -118,9 +120,47 @@ export class Boxer {
   playOnce(key) {
     if (this.sprite.anims.currentAnim?.key !== key) {
       this.sprite.play(key);
+      if (
+        key === `${this.prefix}_jabRight` ||
+        key === `${this.prefix}_jabLeft` ||
+        key === `${this.prefix}_uppercut`
+      ) {
+        this.hasHit = false;
+      }
       this.sprite.once('animationcomplete', () => {
         this.sprite.play(`${this.prefix}_idle`);
       });
+    }
+  }
+
+  isAttacking() {
+    const key = this.sprite.anims.currentAnim?.key;
+    return (
+      key === `${this.prefix}_jabRight` ||
+      key === `${this.prefix}_jabLeft` ||
+      key === `${this.prefix}_uppercut`
+    );
+  }
+
+  isBlocking() {
+    const key = this.sprite.anims.currentAnim?.key;
+    return key === `${this.prefix}_block`;
+  }
+
+  takeDamage(amount) {
+    this.health = Phaser.Math.Clamp(this.health - amount, 0, 1);
+
+    if (this.health === 0) {
+      this.sprite.play(`${this.prefix}_ko`);
+      return;
+    }
+
+    if (this.health < 0.3) {
+      this.playOnce(`${this.prefix}_dizzy`);
+    } else if (this.health < 0.4) {
+      this.playOnce(`${this.prefix}_hurt2`);
+    } else if (this.health < 0.6) {
+      this.playOnce(`${this.prefix}_hurt1`);
     }
   }
 }

--- a/src/scripts/game-scene.js
+++ b/src/scripts/game-scene.js
@@ -233,11 +233,38 @@ export class GameScene extends Phaser.Scene {
     this.player1 = new Boxer(this, 200, 400, 'boxer1', controller1);
     this.player2 = new Boxer(this, 600, 400, 'boxer2', controller2);
 
+    this.ui = this.scene.get('OverlayUI');
+
     console.log('GameScene: create complete');
   }
 
   update(time, delta) {
     this.player1.update(delta);
     this.player2.update(delta);
+
+    this.handleHit(this.player1, this.player2, 'p2');
+    this.handleHit(this.player2, this.player1, 'p1');
+  }
+
+  handleHit(attacker, defender, defenderKey) {
+    if (!attacker.isAttacking() || attacker.hasHit) return;
+    if (defender.isBlocking()) return;
+
+    if (
+      (attacker.facingRight && defender.sprite.x < attacker.sprite.x) ||
+      (!attacker.facingRight && defender.sprite.x > attacker.sprite.x)
+    ) {
+      return;
+    }
+
+    const aBounds = attacker.sprite.getBounds();
+    const dBounds = defender.sprite.getBounds();
+    if (Phaser.Geom.Intersects.RectangleToRectangle(aBounds, dBounds)) {
+      attacker.hasHit = true;
+      defender.takeDamage(0.1);
+      if (this.ui) {
+        this.ui.setBarValue(this.ui.bars[defenderKey].health, defender.health);
+      }
+    }
   }
 }


### PR DESCRIPTION
## Summary
- add health and hit tracking to Boxer
- trigger status animations based on health thresholds
- implement `handleHit` in GameScene for basic punch collision
- update overlay health bars when damage is taken

## Testing
- `node --version`

------
https://chatgpt.com/codex/tasks/task_e_688a9440ad44832aafb5e6b64e5938c2