### PR TITLE
Improve boxer placement and KO handling

### DIFF
--- a/src/scripts/boxer.js
+++ b/src/scripts/boxer.js
@@ -11,7 +11,8 @@ export class Boxer {
     this.stamina = stats.stamina || 1;
     this.maxHealth = stats.health || 1;
     this.health = this.maxHealth;
-    this.sprite.setScale(400 / this.sprite.height);
+    // slightly smaller boxer sprites
+    this.sprite.setScale(350 / this.sprite.height);
     // boxer1 faces right, boxer2 faces left
     this.facingRight = prefix === 'boxer1';
     this.sprite.setFlipX(this.facingRight);
@@ -48,7 +49,8 @@ export class Boxer {
     }
 
     if (this.isKO) {
-      this.sprite.anims.play(`${this.prefix}_ko`, true);
+      // KO animation is triggered when the knockout occurs, so simply
+      // keep the boxer in the final KO frame without replaying it.
       return;
     }
     if (this.isWinner) {

--- a/src/scripts/match-scene.js
+++ b/src/scripts/match-scene.js
@@ -241,11 +241,12 @@ export class MatchScene extends Phaser.Scene {
     const margin = 50;
     this.player1Start = {
       x: centerX - ringWidth / 2 + margin,
-      y: centerY + 100,
+      // start closer to the middle of the ring vertically
+      y: centerY,
     };
     this.player2Start = {
       x: centerX + ringWidth / 2 - margin,
-      y: centerY + 100,
+      y: centerY,
     };
     this.player1 = new Boxer(
       this,


### PR DESCRIPTION
## Summary
- keep boxers in center of the ring at the start of each round
- reduce boxer sprite scale for a better fit
- stop replaying KO animation so defeated fighters stay down

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688b63ac3a58832abe08d365e3b33c01