### PR TITLE
Decouple UI via event bus

### DIFF
--- a/src/scripts/event-bus.js
+++ b/src/scripts/event-bus.js
@@ -1,0 +1,1 @@
+export const eventBus = new Phaser.Events.EventEmitter();

--- a/src/scripts/health-manager.js
+++ b/src/scripts/health-manager.js
@@ -1,0 +1,24 @@
+import { eventBus } from './event-bus.js';
+
+export class HealthManager {
+  constructor(boxer1, boxer2) {
+    this.boxer1 = boxer1;
+    this.boxer2 = boxer2;
+  }
+
+  reset() {
+    this.boxer1.health = this.boxer1.maxHealth;
+    this.boxer2.health = this.boxer2.maxHealth;
+    eventBus.emit('health-changed', { player: 'p1', value: 1 });
+    eventBus.emit('health-changed', { player: 'p2', value: 1 });
+  }
+
+  damage(targetKey, amount) {
+    const boxer = targetKey === 'p1' ? this.boxer1 : this.boxer2;
+    boxer.takeDamage(amount);
+    eventBus.emit('health-changed', {
+      player: targetKey,
+      value: boxer.health / boxer.maxHealth,
+    });
+  }
+}

--- a/src/scripts/round-timer.js
+++ b/src/scripts/round-timer.js
@@ -1,0 +1,39 @@
+import { eventBus } from './event-bus.js';
+
+export class RoundTimer {
+  constructor(scene) {
+    this.scene = scene;
+    this.remaining = 0;
+    this.timerEvent = null;
+    this.round = 1;
+  }
+
+  start(seconds, round = 1) {
+    this.stop();
+    this.remaining = seconds;
+    this.round = round;
+    eventBus.emit('round-started', this.round);
+    eventBus.emit('timer-tick', this.remaining);
+    this.timerEvent = this.scene.time.addEvent({
+      delay: 1000,
+      loop: true,
+      callback: () => {
+        this.remaining -= 1;
+        eventBus.emit('timer-tick', this.remaining);
+        if (this.remaining <= 0) {
+          this.stop();
+          eventBus.emit('round-ended', this.round);
+        }
+      },
+    });
+  }
+
+  stop() {
+    if (this.timerEvent) {
+      this.timerEvent.remove();
+      this.timerEvent = null;
+    }
+    this.remaining = 0;
+    eventBus.emit('timer-tick', this.remaining);
+  }
+}


### PR DESCRIPTION
## Summary
- add lightweight `eventBus`
- move round timing to new `RoundTimer`
- handle player health through `HealthManager`
- refactor OverlayUI to subscribe to events instead of driving logic
- update MatchScene to emit events for UI instead of direct calls

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_688b85fe53f8832a93f4a7eac85c7291