### PR TITLE
Refactor animation key handling

### DIFF
--- a/src/scripts/animation-factory.js
+++ b/src/scripts/animation-factory.js
@@ -1,3 +1,5 @@
+import { animKey } from './helpers.js';
+
 export const ANIM_DEFS = {
   idle: { frameCount: 10, repeat: -1 },
   forward: { frameCount: 10, repeat: -1 },
@@ -21,7 +23,7 @@ export function createBoxerAnimations(scene, prefix) {
       frames.push({ key: `${key}_${frame}` });
     }
     scene.anims.create({
-      key: `${prefix}_${key}`,
+      key: animKey(prefix, key),
       frames,
       frameRate: 10,
       repeat,

--- a/src/scripts/boxer.js
+++ b/src/scripts/boxer.js
@@ -1,3 +1,5 @@
+import { BOXER_PREFIXES, animKey } from './helpers.js';
+
 export const States = {
   ATTACK: 'attack',
   INJURED: 'injured',
@@ -29,7 +31,7 @@ export class Boxer {
   constructor(scene, x, y, prefix, controller, stats = {}) {
     this.scene = scene;
     this.sprite = scene.add.sprite(x, y, 'idle_000');
-    this.sprite.play(`${prefix}_idle`);
+    this.sprite.play(animKey(prefix, 'idle'));
     this.prefix = prefix;
     this.controller = controller;
     this.stats = stats;
@@ -41,9 +43,9 @@ export class Boxer {
     // slightly smaller boxer sprites
     this.sprite.setScale(350 / this.sprite.height);
     // boxer1 faces right, boxer2 faces left
-    this.facingRight = prefix === 'boxer1';
+    this.facingRight = prefix === BOXER_PREFIXES.P1;
     this.sprite.setFlipX(this.facingRight);
-    if (prefix === 'boxer2') this.sprite.setTint(0xbb7744);
+    if (prefix === BOXER_PREFIXES.P2) this.sprite.setTint(0xbb7744);
     this.hasHit = false;
     this.isKO = false;
     this.isWinner = false;
@@ -61,7 +63,7 @@ export class Boxer {
   playAction(action) {
     const cfg = ACTION_ANIMS[action];
     if (!cfg) return;
-    const key = `${this.prefix}_${cfg.key}`;
+    const key = animKey(this.prefix, cfg.key);
     if (cfg.loop) {
       this.sprite.anims.play(key, true);
     } else {
@@ -114,13 +116,13 @@ export class Boxer {
   }
 
   triggerKO() {
-    this.sprite.play(`${this.prefix}_ko`);
+    this.sprite.play(animKey(this.prefix, 'ko'));
     this.isKO = true;
     this.scene.events.emit('boxer-ko', this);
   }
 
   triggerWin() {
-    this.sprite.anims.play(`${this.prefix}_win`, true);
+    this.sprite.anims.play(animKey(this.prefix, 'win'), true);
     this.isWinner = true;
   }
 
@@ -186,14 +188,14 @@ export class Boxer {
     if (this.sprite.anims.currentAnim?.key !== key) {
       this.sprite.play(key);
       if (
-        key === `${this.prefix}_jabRight` ||
-        key === `${this.prefix}_jabLeft` ||
-        key === `${this.prefix}_uppercut`
+        key === animKey(this.prefix, 'jabRight') ||
+        key === animKey(this.prefix, 'jabLeft') ||
+        key === animKey(this.prefix, 'uppercut')
       ) {
         this.hasHit = false;
       }
       this.sprite.once('animationcomplete', () => {
-        this.sprite.play(`${this.prefix}_idle`);
+        this.sprite.play(animKey(this.prefix, 'idle'));
       });
     }
   }
@@ -201,33 +203,33 @@ export class Boxer {
   isAttacking() {
     const key = this.sprite.anims.currentAnim?.key;
     return (
-      key === `${this.prefix}_jabRight` ||
-      key === `${this.prefix}_jabLeft` ||
-      key === `${this.prefix}_uppercut`
+      key === animKey(this.prefix, 'jabRight') ||
+      key === animKey(this.prefix, 'jabLeft') ||
+      key === animKey(this.prefix, 'uppercut')
     );
   }
 
   isBlocking() {
     const key = this.sprite.anims.currentAnim?.key;
-    return key === `${this.prefix}_block`;
+    return key === animKey(this.prefix, 'block');
   }
 
   takeDamage(amount) {
     this.health = Phaser.Math.Clamp(this.health - amount, 0, this.maxHealth);
 
     if (this.health === 0) {
-      this.sprite.play(`${this.prefix}_ko`);
+      this.sprite.play(animKey(this.prefix, 'ko'));
       this.isKO = true;
       this.scene.events.emit('boxer-ko', this);
       return;
     }
 
     if (this.health < 0.3) {
-      this.playOnce(`${this.prefix}_dizzy`);
+      this.playOnce(animKey(this.prefix, 'dizzy'));
     } else if (this.health < 0.4) {
-      this.playOnce(`${this.prefix}_hurt2`);
+      this.playOnce(animKey(this.prefix, 'hurt2'));
     } else if (this.health < 0.6) {
-      this.playOnce(`${this.prefix}_hurt1`);
+      this.playOnce(animKey(this.prefix, 'hurt1'));
     }
   }
 }

--- a/src/scripts/helpers.js
+++ b/src/scripts/helpers.js
@@ -1,0 +1,8 @@
+export const BOXER_PREFIXES = {
+  P1: 'boxer1',
+  P2: 'boxer2',
+};
+
+export function animKey(prefix, name) {
+  return `${prefix}_${name}`;
+}

--- a/src/scripts/match-scene.js
+++ b/src/scripts/match-scene.js
@@ -4,6 +4,7 @@ import { createBoxerAnimations } from './animation-factory.js';
 import { eventBus } from './event-bus.js';
 import { RoundTimer } from './round-timer.js';
 import { HealthManager } from './health-manager.js';
+import { BOXER_PREFIXES, animKey } from './helpers.js';
 
 export class MatchScene extends Phaser.Scene {
   constructor() {
@@ -21,8 +22,8 @@ export class MatchScene extends Phaser.Scene {
     this.add.image(width / 2, height / 2, 'ring').setDisplaySize(880, 660);
 
     // create animations for both boxers
-    createBoxerAnimations(this, 'boxer1');
-    createBoxerAnimations(this, 'boxer2');
+    createBoxerAnimations(this, BOXER_PREFIXES.P1);
+    createBoxerAnimations(this, BOXER_PREFIXES.P2);
 
     // controllers (swapped controls so the boxer on the right uses the
     // right-hand keys)
@@ -72,7 +73,7 @@ export class MatchScene extends Phaser.Scene {
       this,
       this.player1Start.x,
       this.player1Start.y,
-      'boxer1',
+      BOXER_PREFIXES.P1,
       controller1,
       data?.boxer1
     );
@@ -80,7 +81,7 @@ export class MatchScene extends Phaser.Scene {
       this,
       this.player2Start.x,
       this.player2Start.y,
-      'boxer2',
+      BOXER_PREFIXES.P2,
       controller2,
       data?.boxer2
     );
@@ -150,8 +151,8 @@ export class MatchScene extends Phaser.Scene {
     this.player2.facingRight = false;
     this.player1.sprite.setFlipX(true);
     this.player2.sprite.setFlipX(false);
-    this.player1.sprite.anims.play('boxer1_idle');
-    this.player2.sprite.anims.play('boxer2_idle');
+    this.player1.sprite.anims.play(animKey(BOXER_PREFIXES.P1, 'idle'));
+    this.player2.sprite.anims.play(animKey(BOXER_PREFIXES.P2, 'idle'));
   }
 
   endRound(round) {
@@ -165,9 +166,9 @@ export class MatchScene extends Phaser.Scene {
     this.matchOver = true;
     const winner = loser === this.player1 ? this.player2 : this.player1;
     loser.isKO = true;
-    loser.sprite.anims.play(`${loser.prefix}_ko`);
+    loser.sprite.anims.play(animKey(loser.prefix, 'ko'));
     winner.isWinner = true;
-    winner.sprite.play(`${winner.prefix}_win`);
+    winner.sprite.play(animKey(winner.prefix, 'win'));
     this.roundTimer.stop();
     eventBus.emit('match-winner', winner.stats?.name || winner.prefix);
   }


### PR DESCRIPTION
## Summary
- centralize boxer prefixes and animation key helper
- update boxer logic to use new helpers
- apply helper to animation factory and match scene

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688b8ae14364832aade2d97edc117cbe