### PR TITLE
Refactor handleHit helpers

### DIFF
--- a/src/scripts/match-scene.js
+++ b/src/scripts/match-scene.js
@@ -118,30 +118,35 @@ export class MatchScene extends Phaser.Scene {
   handleHit(attacker, defender, defenderKey) {
     if (!attacker.isAttacking() || attacker.hasHit) return;
     if (defender.isBlocking()) return;
+    if (!this.isFacingCorrectly(attacker, defender)) return;
+    if (!this.isInRange(attacker, defender)) return;
+    if (!this.isColliding(attacker, defender)) return;
 
-    if (
+    attacker.hasHit = true;
+    this.healthManager.damage(defenderKey, 0.05 * attacker.power);
+  }
+
+  isFacingCorrectly(attacker, defender) {
+    return !(
       (attacker.facingRight && defender.sprite.x < attacker.sprite.x) ||
       (!attacker.facingRight && defender.sprite.x > attacker.sprite.x)
-    ) {
-      return;
-    }
+    );
+  }
 
+  isInRange(attacker, defender) {
     const distance = Phaser.Math.Distance.Between(
       attacker.sprite.x,
       attacker.sprite.y,
       defender.sprite.x,
       defender.sprite.y
     );
+    return distance <= this.hitLimit;
+  }
 
+  isColliding(attacker, defender) {
     const aBounds = attacker.sprite.getBounds();
     const dBounds = defender.sprite.getBounds();
-    if (
-      distance <= this.hitLimit &&
-      Phaser.Geom.Intersects.RectangleToRectangle(aBounds, dBounds)
-    ) {
-      attacker.hasHit = true;
-      this.healthManager.damage(defenderKey, 0.05 * attacker.power);
-    }
+    return Phaser.Geom.Intersects.RectangleToRectangle(aBounds, dBounds);
   }
 
   resetBoxers() {


### PR DESCRIPTION
## Summary
- split hit logic into `isFacingCorrectly`, `isInRange`, and `isColliding`
- use these helpers in `handleHit`

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_688b8cda42f0832aa0566f0e631abc04