### PR TITLE
Adjust hit range damage and cleanup

### DIFF
--- a/src/scripts/main.js
+++ b/src/scripts/main.js
@@ -78,9 +78,6 @@ class BootScene extends Phaser.Scene {
         `assets/7-Win/__Boxer2_win_${frame}.png`
       );
     }
-    // Legacy punch sprite sheets were removed from the project. The
-    // animations now rely solely on the individual frame images loaded
-    // above, so skip loading these missing assets.
   }
 
   create() {

--- a/src/scripts/match-scene.js
+++ b/src/scripts/match-scene.js
@@ -14,7 +14,7 @@ export class MatchScene extends Phaser.Scene {
   create(data) {
     console.log('MatchScene: create started');
 
-    this.hitLimit = 320; // max distance for a hit to register
+    this.hitLimit = 280; // max distance for a hit to register
 
     const width = this.sys.game.config.width;
     const height = this.sys.game.config.height;
@@ -119,11 +119,19 @@ export class MatchScene extends Phaser.Scene {
     if (!attacker.isAttacking() || attacker.hasHit) return;
     if (defender.isBlocking()) return;
     if (!this.isFacingCorrectly(attacker, defender)) return;
-    if (!this.isInRange(attacker, defender)) return;
+    const distance = Phaser.Math.Distance.Between(
+      attacker.sprite.x,
+      attacker.sprite.y,
+      defender.sprite.x,
+      defender.sprite.y
+    );
+    if (distance > this.hitLimit) return;
     if (!this.isColliding(attacker, defender)) return;
 
     attacker.hasHit = true;
-    this.healthManager.damage(defenderKey, 0.05 * attacker.power);
+    let damage = 0.05 * attacker.power;
+    if (distance >= 200) damage *= 0.5;
+    this.healthManager.damage(defenderKey, damage);
   }
 
   isFacingCorrectly(attacker, defender) {


### PR DESCRIPTION
## Summary
- remove outdated comment in `main.js`
- lower `hitLimit` to 280 and vary damage based on distance

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688ba5e35f4c832a8b29820a6f711065