### PR TITLE
Improve boxer recovery and block behavior

### DIFF
--- a/src/scripts/boxer.js
+++ b/src/scripts/boxer.js
@@ -55,6 +55,7 @@ export class Boxer {
     this.baseStrategy = controller.currentName;
     this.recoveryTimer = 0;
     this.lowStaminaMode = false;
+    this.blockHoldTime = 0;
   }
 
   getCurrentState() {
@@ -173,6 +174,17 @@ export class Boxer {
     }
 
     this.applyRecovery(delta, actions);
+
+    if (actions.block && this.blockHoldTime <= 0) {
+      this.blockHoldTime = 2000;
+    }
+    if (this.blockHoldTime > 0) {
+      this.blockHoldTime -= delta;
+      actions.block = true;
+      actions.jabRight = false;
+      actions.jabLeft = false;
+      actions.uppercut = false;
+    }
 
     this.handleFacing(actions);
 
@@ -306,7 +318,7 @@ export class Boxer {
 
   applyRecovery(delta, actions) {
     this.recoveryTimer += delta;
-    if (this.recoveryTimer >= 2000) {
+    if (this.recoveryTimer >= 1000) {
       const movingBackward =
         (actions.moveLeft && this.facingRight) ||
         (actions.moveRight && !this.facingRight);


### PR DESCRIPTION
## Summary
- speed up boxer recovery by reducing timer interval to 1 second
- keep blocking pose for at least two seconds once triggered

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688bdc31b324832aba90724b7394b687