### PR TITLE
Improve stamina drain and block recovery

### DIFF
--- a/src/scripts/boxer.js
+++ b/src/scripts/boxer.js
@@ -175,15 +175,19 @@ export class Boxer {
 
     this.applyRecovery(delta, actions);
 
-    if (actions.block && this.blockHoldTime <= 0) {
-      this.blockHoldTime = 2000;
-    }
-    if (this.blockHoldTime > 0) {
-      this.blockHoldTime -= delta;
-      actions.block = true;
-      actions.jabRight = false;
-      actions.jabLeft = false;
-      actions.uppercut = false;
+    if (this.lowStaminaMode) {
+      if (actions.block && this.blockHoldTime <= 0) {
+        this.blockHoldTime = 1000;
+      }
+      if (this.blockHoldTime > 0) {
+        this.blockHoldTime -= delta;
+        actions.block = true;
+        actions.jabRight = false;
+        actions.jabLeft = false;
+        actions.uppercut = false;
+      }
+    } else {
+      this.blockHoldTime = 0;
     }
 
     this.handleFacing(actions);
@@ -240,7 +244,7 @@ export class Boxer {
     const movingForward =
       (actions.moveRight && this.facingRight) ||
       (actions.moveLeft && !this.facingRight);
-    if (movingForward) this.adjustStamina(-0.01);
+    if (movingForward) this.adjustStamina(-0.001);
 
     this.applyBounds();
   }


### PR DESCRIPTION
## Summary
- reduce stamina loss when moving forward
- shorten forced block duration and release it when stamina recovers

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688bdf16f8a8832a9ad5c317a024180d