### PR TITLE
Reduce stamina drain and prevent long range punching

### DIFF
--- a/src/scripts/ai-strategies.js
+++ b/src/scripts/ai-strategies.js
@@ -21,6 +21,8 @@ function baseActions() {
   };
 }
 
+const FAR_DISTANCE = 400;
+
 export class OffensiveStrategy {
   decide(boxer, opponent) {
     const actions = baseActions();
@@ -40,10 +42,17 @@ export class OffensiveStrategy {
         actions.moveRight = true;
       }
     }
-    actions.block = Math.random() < 0.05;
-    actions.jabRight = Math.random() < 0.4;
-    actions.jabLeft = Math.random() < 0.4;
-    actions.uppercut = Math.random() < 0.2;
+
+    if (distance <= FAR_DISTANCE) {
+      actions.block = Math.random() < 0.05;
+      actions.jabRight = Math.random() < 0.4;
+      actions.jabLeft = Math.random() < 0.4;
+      actions.uppercut = Math.random() < 0.2;
+    } else if (boxer.stamina / boxer.maxStamina > 0.5) {
+      if (boxer.sprite.x < opponent.sprite.x) actions.moveRight = true;
+      else actions.moveLeft = true;
+    }
+
     return actions;
   }
 }
@@ -67,10 +76,15 @@ export class DefensiveStrategy {
         actions.moveLeft = true;
       }
     }
-    actions.block = Math.random() < 0.6;
-    actions.jabRight = Math.random() < 0.1;
-    actions.jabLeft = Math.random() < 0.1;
-    actions.uppercut = Math.random() < 0.05;
+    if (distance <= FAR_DISTANCE) {
+      actions.block = Math.random() < 0.6;
+      actions.jabRight = Math.random() < 0.1;
+      actions.jabLeft = Math.random() < 0.1;
+      actions.uppercut = Math.random() < 0.05;
+    } else if (boxer.stamina / boxer.maxStamina > 0.5) {
+      if (boxer.sprite.x < opponent.sprite.x) actions.moveRight = true;
+      else actions.moveLeft = true;
+    }
     return actions;
   }
 }
@@ -101,10 +115,15 @@ export class NeutralStrategy {
         actions.moveRight = true;
       }
     }
-    actions.block = Math.random() < 0.3;
-    actions.jabRight = Math.random() < 0.25;
-    actions.jabLeft = Math.random() < 0.25;
-    actions.uppercut = Math.random() < 0.1;
+    if (distance <= FAR_DISTANCE) {
+      actions.block = Math.random() < 0.3;
+      actions.jabRight = Math.random() < 0.25;
+      actions.jabLeft = Math.random() < 0.25;
+      actions.uppercut = Math.random() < 0.1;
+    } else if (boxer.stamina / boxer.maxStamina > 0.5) {
+      if (boxer.sprite.x < opponent.sprite.x) actions.moveRight = true;
+      else actions.moveLeft = true;
+    }
     return actions;
   }
 }

--- a/src/scripts/boxer.js
+++ b/src/scripts/boxer.js
@@ -244,7 +244,7 @@ export class Boxer {
     const movingForward =
       (actions.moveRight && this.facingRight) ||
       (actions.moveLeft && !this.facingRight);
-    if (movingForward) this.adjustStamina(-0.001);
+    if (movingForward) this.adjustStamina(-0.0006);
 
     this.applyBounds();
   }
@@ -258,8 +258,8 @@ export class Boxer {
         key === animKey(this.prefix, 'uppercut')
       ) {
         this.hasHit = false;
-        this.adjustPower(-0.05);
-        this.adjustStamina(-0.05);
+        this.adjustPower(-0.03);
+        this.adjustStamina(-0.03);
       }
       this.sprite.once('animationcomplete', () => {
         this.sprite.play(animKey(this.prefix, 'idle'));
@@ -327,8 +327,8 @@ export class Boxer {
         (actions.moveLeft && this.facingRight) ||
         (actions.moveRight && !this.facingRight);
       if (actions.block || movingBackward) {
-        this.adjustStamina(0.02);
-        this.adjustHealth(0.02);
+        this.adjustStamina(0.03);
+        this.adjustHealth(0.03);
       }
       this.adjustPower(0.1 * this.stamina);
       this.recoveryTimer = 0;

--- a/src/scripts/match-scene.js
+++ b/src/scripts/match-scene.js
@@ -102,8 +102,8 @@ export class MatchScene extends Phaser.Scene {
     if (distance > this.hitLimit) return;
     if (!this.isColliding(attacker, defender)) return;
     if (defender.isBlocking()) {
-      attacker.adjustPower(-0.1);
-      attacker.adjustStamina(-0.1);
+      attacker.adjustPower(-0.06);
+      attacker.adjustStamina(-0.06);
       return;
     }
 


### PR DESCRIPTION
## Summary
- tune stamina system so fighters last longer
- tweak block penalties
- stop AI from punching when opponent is more than 400px away

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688be1354f98832a9d2b738b19546b42