### PR TITLE
Increase boxer recovery and reduce attack range

### DIFF
--- a/src/scripts/ai-strategies.js
+++ b/src/scripts/ai-strategies.js
@@ -21,7 +21,7 @@ function baseActions() {
   };
 }
 
-const FAR_DISTANCE = 400;
+const FAR_DISTANCE = 300;
 
 export class OffensiveStrategy {
   decide(boxer, opponent) {

--- a/src/scripts/boxer.js
+++ b/src/scripts/boxer.js
@@ -327,10 +327,10 @@ export class Boxer {
         (actions.moveLeft && this.facingRight) ||
         (actions.moveRight && !this.facingRight);
       if (actions.block || movingBackward) {
-        this.adjustStamina(0.03);
-        this.adjustHealth(0.03);
+        this.adjustStamina(0.05);
+        this.adjustHealth(0.05);
       }
-      this.adjustPower(0.1 * this.stamina);
+      this.adjustPower(0.15 * this.stamina);
       this.recoveryTimer = 0;
     }
   }


### PR DESCRIPTION
## Summary
- speed up stamina, health, and power recovery
- reduce FAR_DISTANCE for AI attack range to 300

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688be36b2970832a9891dfec5308517b