### PR TITLE
Adjust fatigue recovery and blocking damage

### DIFF
--- a/src/scripts/boxer.js
+++ b/src/scripts/boxer.js
@@ -143,7 +143,7 @@ export class Boxer {
     if (this.lowStaminaMode === undefined) this.lowStaminaMode = false;
     if (this.stamina < 0.31) {
       this.lowStaminaMode = true;
-    } else if (this.lowStaminaMode && this.stamina > 0.3) {
+    } else if (this.lowStaminaMode && this.stamina > 0.5) {
       this.lowStaminaMode = false;
     }
     if (this.lowStaminaMode) {
@@ -259,7 +259,7 @@ export class Boxer {
       ) {
         this.hasHit = false;
         this.adjustPower(-0.03);
-        this.adjustStamina(-0.03);
+        this.adjustStamina(-0.015);
       }
       this.sprite.once('animationcomplete', () => {
         this.sprite.play(animKey(this.prefix, 'idle'));

--- a/src/scripts/match-scene.js
+++ b/src/scripts/match-scene.js
@@ -101,15 +101,16 @@ export class MatchScene extends Phaser.Scene {
     );
     if (distance > this.hitLimit) return;
     if (!this.isColliding(attacker, defender)) return;
-    if (defender.isBlocking()) {
-      attacker.adjustPower(-0.06);
-      attacker.adjustStamina(-0.06);
-      return;
-    }
-
     attacker.hasHit = true;
     let damage = 0.05 * attacker.power;
     if (distance >= 200) damage *= 0.5;
+
+    if (defender.isBlocking()) {
+      attacker.adjustPower(-0.06);
+      attacker.adjustStamina(-0.06);
+      damage *= 0.5;
+    }
+
     this.healthManager.damage(defenderKey, damage);
   }
 


### PR DESCRIPTION
## Summary
- tweak stamina recovery threshold
- reduce stamina cost for punches
- deal 50% damage when blocking

## Testing
- `npm test` *(fails: cannot find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688be597eeec832a9dd8b2889008cf70