### PR TITLE
Improve uppercut damage and round display

### DIFF
--- a/src/scripts/boxer.js
+++ b/src/scripts/boxer.js
@@ -258,8 +258,11 @@ export class Boxer {
         key === animKey(this.prefix, 'uppercut')
       ) {
         this.hasHit = false;
-        this.adjustPower(-0.03);
-        this.adjustStamina(-0.015);
+        const isUppercut = key === animKey(this.prefix, 'uppercut');
+        const powerCost = isUppercut ? 0.06 : 0.03;
+        const staminaCost = isUppercut ? 0.03 : 0.015;
+        this.adjustPower(-powerCost);
+        this.adjustStamina(-staminaCost);
       }
       this.sprite.once('animationcomplete', () => {
         this.sprite.play(animKey(this.prefix, 'idle'));
@@ -328,7 +331,7 @@ export class Boxer {
         (actions.moveRight && !this.facingRight);
       if (actions.block || movingBackward) {
         this.adjustStamina(0.05);
-        this.adjustHealth(0.05);
+        this.adjustHealth(0.02);
       }
       this.adjustPower(0.15 * this.stamina);
       this.recoveryTimer = 0;

--- a/src/scripts/match-scene.js
+++ b/src/scripts/match-scene.js
@@ -102,12 +102,16 @@ export class MatchScene extends Phaser.Scene {
     if (distance > this.hitLimit) return;
     if (!this.isColliding(attacker, defender)) return;
     attacker.hasHit = true;
+    const current = attacker.sprite.anims.currentAnim?.key;
+    const isUppercut = current === animKey(attacker.prefix, 'uppercut');
     let damage = 0.05 * attacker.power;
+    if (isUppercut) damage *= 2;
     if (distance >= 200) damage *= 0.5;
 
     if (defender.isBlocking()) {
-      attacker.adjustPower(-0.06);
-      attacker.adjustStamina(-0.06);
+      const penalty = isUppercut ? 0.12 : 0.06;
+      attacker.adjustPower(-penalty);
+      attacker.adjustStamina(-penalty);
       damage *= 0.5;
     }
 

--- a/src/scripts/overlay.js
+++ b/src/scripts/overlay.js
@@ -99,10 +99,7 @@ export class OverlayUI extends Phaser.Scene {
 
   showRound(number) {
     if (!this.roundText) return;
-    this.roundText.setText(`Round ${number}`);
-    this.time.delayedCall(2000, () => {
-      if (this.roundText) this.roundText.setText('');
-    });
+    this.roundText.setText(`Rond ${number}`);
   }
 
   setNames(p1, p2) {


### PR DESCRIPTION
## Summary
- show current round at all times
- slow down health regeneration
- make uppercuts cost more stamina/power
- double damage for uppercut hits

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688be79e8aac832a9126574dc5061299