### PR TITLE
Freeze time on KO

### DIFF
--- a/src/scripts/boxer.js
+++ b/src/scripts/boxer.js
@@ -206,7 +206,9 @@ export class Boxer {
     for (const h of handlers) {
       if (h.check()) {
         h.action();
-        this.applyMovement(actions, move);
+        if (!this.isKO && !this.isWinner) {
+          this.applyMovement(actions, move);
+        }
         this.applyBounds();
         return;
       }

--- a/src/scripts/match-scene.js
+++ b/src/scripts/match-scene.js
@@ -166,7 +166,7 @@ export class MatchScene extends Phaser.Scene {
     loser.sprite.anims.play(animKey(loser.prefix, 'ko'));
     winner.isWinner = true;
     winner.sprite.play(animKey(winner.prefix, 'win'));
-    this.roundTimer.stop();
+    this.roundTimer.pause();
     eventBus.emit('match-winner', winner.stats?.name || winner.prefix);
   }
 

--- a/src/scripts/round-timer.js
+++ b/src/scripts/round-timer.js
@@ -36,4 +36,12 @@ export class RoundTimer {
     this.remaining = 0;
     eventBus.emit('timer-tick', this.remaining);
   }
+
+  pause() {
+    if (this.timerEvent) {
+      this.timerEvent.remove();
+      this.timerEvent = null;
+    }
+    eventBus.emit('timer-tick', this.remaining);
+  }
 }


### PR DESCRIPTION
## Summary
- prevent boxers from moving after a knockout
- pause the round timer when KO happens
- add pause method for RoundTimer

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688be9f54624832aa0459cb609338bbd