### PR TITLE
Add diagnostic overlay and pause toggle

### DIFF
--- a/src/scripts/boxer.js
+++ b/src/scripts/boxer.js
@@ -58,6 +58,7 @@ export class Boxer {
     this.isRetreating = false;
     this.wasTired = false;
     this.opponentWasTired = false;
+    this.lastAction = 'idle';
   }
 
   getCurrentState() {
@@ -73,6 +74,7 @@ export class Boxer {
     const cfg = ACTION_ANIMS[action];
     if (!cfg) return;
     const key = animKey(this.prefix, cfg.key);
+    this.lastAction = action;
     if (cfg.loop) {
       this.sprite.anims.play(key, true);
     } else {
@@ -322,7 +324,7 @@ export class Boxer {
         this.adjustStamina(-staminaCost);
       }
       this.sprite.once('animationcomplete', () => {
-        this.sprite.play(animKey(this.prefix, 'idle'));
+        this.playAction('idle');
       });
     }
   }

--- a/src/scripts/match-scene.js
+++ b/src/scripts/match-scene.js
@@ -79,10 +79,43 @@ export class MatchScene extends Phaser.Scene {
     this.events.on('boxer-ko', (b) => this.handleKO(b));
     this.matchOver = false;
 
+    this.paused = false;
+    this.debugText = this.add
+      .text(width / 2, height - 100, '', {
+        font: '16px monospace',
+        color: '#ffffff',
+        align: 'center',
+      })
+      .setOrigin(0.5, 0);
+    this.input.keyboard.on('keydown-P', (event) => {
+      if (event.ctrlKey) {
+        this.togglePause();
+      }
+    });
+
     console.log('MatchScene: create complete');
   }
 
   update(time, delta) {
+    const distance = Phaser.Math.Distance.Between(
+      this.player1.sprite.x,
+      this.player1.sprite.y,
+      this.player2.sprite.x,
+      this.player2.sprite.y
+    );
+    const action1 = this.player1.lastAction;
+    const action2 = this.player2.lastAction;
+    const statsLine =
+      `P1 S:${this.player1.stamina.toFixed(2)} H:${this.player1.health.toFixed(2)} P:${this.player1.power.toFixed(2)} | ` +
+      `P2 S:${this.player2.stamina.toFixed(2)} H:${this.player2.health.toFixed(2)} P:${this.player2.power.toFixed(2)}`;
+    this.debugText.setText([
+      `Distans: ${distance.toFixed(1)}`,
+      `P1: ${action1} | P2: ${action2}`,
+      statsLine,
+    ]);
+
+    if (this.paused) return;
+
     this.player1.update(delta, this.player2);
     this.player2.update(delta, this.player1);
 
@@ -173,5 +206,18 @@ export class MatchScene extends Phaser.Scene {
   setPlayerStrategy(player, level) {
     const ctrl = player === 1 ? this.player1.controller : this.player2.controller;
     if (ctrl && ctrl.setLevel) ctrl.setLevel(level);
+  }
+
+  togglePause() {
+    this.paused = !this.paused;
+    if (this.paused) {
+      this.roundTimer.pause();
+      this.player1.sprite.anims.pause();
+      this.player2.sprite.anims.pause();
+    } else {
+      this.roundTimer.resume();
+      this.player1.sprite.anims.resume();
+      this.player2.sprite.anims.resume();
+    }
   }
 }

--- a/src/scripts/round-timer.js
+++ b/src/scripts/round-timer.js
@@ -44,4 +44,20 @@ export class RoundTimer {
     }
     eventBus.emit('timer-tick', this.remaining);
   }
+
+  resume() {
+    if (this.timerEvent || this.remaining <= 0) return;
+    this.timerEvent = this.scene.time.addEvent({
+      delay: 500,
+      loop: true,
+      callback: () => {
+        this.remaining -= 1;
+        eventBus.emit('timer-tick', this.remaining);
+        if (this.remaining <= 0) {
+          this.stop();
+          eventBus.emit('round-ended', this.round);
+        }
+      },
+    });
+  }
 }


### PR DESCRIPTION
## Summary
- Display distance, actions, and stamina/health/power diagnostics beneath the boxers
- Track each boxer's most recent action for debugging
- Add Ctrl+P toggle to pause and resume match including timer

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689206334678832a8a19e71adc1d36af