### PR TITLE
Have boxers close distance and tweak stamina

### DIFF
--- a/src/scripts/boxer.js
+++ b/src/scripts/boxer.js
@@ -1,5 +1,6 @@
 import { BOXER_PREFIXES, animKey } from './helpers.js';
 import { eventBus } from './event-bus.js';
+import { createBaseActions } from './ai-strategies.js';
 
 export const States = {
   ATTACK: 'attack',
@@ -247,6 +248,18 @@ export class Boxer {
       }
     }
 
+    const distance = Phaser.Math.Distance.Between(
+      this.sprite.x,
+      this.sprite.y,
+      opponent.sprite.x,
+      opponent.sprite.y
+    );
+    if (distance > 400) {
+      actions = createBaseActions();
+      if (this.sprite.x < opponent.sprite.x) actions.moveRight = true;
+      else actions.moveLeft = true;
+    }
+
     this.handleFacing(actions);
 
     const handlers = [
@@ -303,7 +316,7 @@ export class Boxer {
     const movingForward =
       (actions.moveRight && this.facingRight) ||
       (actions.moveLeft && !this.facingRight);
-    if (movingForward) this.adjustStamina(-0.0006);
+    if (movingForward) this.adjustStamina(-0.0003);
 
     this.applyBounds();
   }

--- a/src/scripts/match-scene.js
+++ b/src/scripts/match-scene.js
@@ -108,10 +108,13 @@ export class MatchScene extends Phaser.Scene {
     const statsLine =
       `P1 S:${this.player1.stamina.toFixed(2)} H:${this.player1.health.toFixed(2)} P:${this.player1.power.toFixed(2)} | ` +
       `P2 S:${this.player2.stamina.toFixed(2)} H:${this.player2.health.toFixed(2)} P:${this.player2.power.toFixed(2)}`;
+    const strategyLine =
+      `Strategi: P1 ${this.player1.controller.getLevel()} | P2 ${this.player2.controller.getLevel()}`;
     this.debugText.setText([
       `Distans: ${distance.toFixed(1)}`,
       `P1: ${action1} | P2: ${action2}`,
       statsLine,
+      strategyLine,
     ]);
 
     if (this.paused) return;


### PR DESCRIPTION
## Summary
- Force fighters to advance toward each other when the gap exceeds 400 units.
- Halve stamina drain for forward movement to prolong endurance.
- Show each fighter's strategy level as a fourth line in the debug HUD.

## Testing
- `node --check src/scripts/boxer.js && echo "boxer ok"`
- `node --check src/scripts/match-scene.js && echo "match ok"`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689209aa8dfc832a9be7287ef6ed890d