### PR TITLE
feat: add distance-based AI behavior with break resets

### DIFF
--- a/src/scripts/ai-strategies.js
+++ b/src/scripts/ai-strategies.js
@@ -54,9 +54,10 @@ function generateStrategy(level) {
   return actions;
 }
 
-export const STRATEGIES = Array.from({ length: 10 }, (_, i) =>
-  generateStrategy(i + 1)
-);
+export const STRATEGIES = Array.from({ length: 10 }, (_, i) => ({
+  distance: 300 - i * 10,
+  actions: generateStrategy(i + 1),
+}));
 
 export function createBaseActions() {
   return baseActions();

--- a/src/scripts/match-scene.js
+++ b/src/scripts/match-scene.js
@@ -79,6 +79,16 @@ export class MatchScene extends Phaser.Scene {
     this.events.on('boxer-ko', (b) => this.handleKO(b));
     this.matchOver = false;
 
+    this.breaking = false;
+    this.breakText = this.add
+      .text(width / 2, height / 2, 'BREAK', {
+        font: '64px Arial',
+        color: '#ffffff',
+        align: 'center',
+      })
+      .setOrigin(0.5)
+      .setVisible(false);
+
     this.paused = false;
     this.debugText = this.add
       .text(width / 2, height - 100, '', {
@@ -103,6 +113,11 @@ export class MatchScene extends Phaser.Scene {
       this.player2.sprite.x,
       this.player2.sprite.y
     );
+
+    if (!this.breaking && distance < 100) {
+      this.resetBoxers();
+      this.showBreak();
+    }
     const action1 = this.player1.lastAction;
     const action2 = this.player2.lastAction;
     const statsLine =
@@ -206,6 +221,15 @@ export class MatchScene extends Phaser.Scene {
   setPlayerStrategy(player, level) {
     const ctrl = player === 1 ? this.player1.controller : this.player2.controller;
     if (ctrl && ctrl.setLevel) ctrl.setLevel(level);
+  }
+
+  showBreak() {
+    this.breaking = true;
+    this.breakText.setVisible(true);
+    this.time.delayedCall(5000, () => {
+      this.breakText.setVisible(false);
+      this.breaking = false;
+    });
   }
 
   togglePause() {

--- a/src/scripts/strategy-ai-controller.js
+++ b/src/scripts/strategy-ai-controller.js
@@ -1,18 +1,35 @@
 import { STRATEGIES, createBaseActions } from './ai-strategies.js';
 
-function convertAction(action, boxer, opponent) {
+function convertAction(action, boxer, opponent, preferredDistance) {
   const res = createBaseActions();
   if (action.block) res.block = true;
   if (action.jabLeft) res.jabLeft = true;
   if (action.jabRight) res.jabRight = true;
   if (action.uppercut) res.uppercut = true;
-  if (action.forward) {
-    if (boxer.sprite.x < opponent.sprite.x) res.moveRight = true;
-    else res.moveLeft = true;
-  }
-  if (action.back) {
-    if (boxer.sprite.x < opponent.sprite.x) res.moveLeft = true;
-    else res.moveRight = true;
+
+  const isAttacking = action.jabLeft || action.jabRight || action.uppercut;
+  const currentDist = Math.abs(boxer.sprite.x - opponent.sprite.x);
+
+  if (isAttacking) {
+    if (action.forward && currentDist > 200) {
+      if (boxer.sprite.x < opponent.sprite.x) res.moveRight = true;
+      else res.moveLeft = true;
+    }
+    if (action.back) {
+      if (boxer.sprite.x < opponent.sprite.x) res.moveLeft = true;
+      else res.moveRight = true;
+    }
+  } else {
+    const oppHealthPct = opponent.health / opponent.maxHealth;
+    const targetDistance = oppHealthPct < 0.3 ? 200 : preferredDistance;
+    const desired = Math.max(200, targetDistance);
+    if (currentDist > desired) {
+      if (boxer.sprite.x < opponent.sprite.x) res.moveRight = true;
+      else res.moveLeft = true;
+    } else if (currentDist < desired) {
+      if (boxer.sprite.x < opponent.sprite.x) res.moveLeft = true;
+      else res.moveRight = true;
+    }
   }
   return res;
 }
@@ -41,9 +58,14 @@ export class StrategyAIController {
   getActions(boxer, opponent) {
     const now = Date.now();
     if (now - this.lastDecision > this.decisionInterval) {
-      const strategy = STRATEGIES[this.level - 1];
-      const action = strategy[this.index % strategy.length];
-      this.cached = convertAction(action, boxer, opponent);
+        const strategy = STRATEGIES[this.level - 1];
+        const action = strategy.actions[this.index % strategy.actions.length];
+        this.cached = convertAction(
+          action,
+          boxer,
+          opponent,
+          strategy.distance
+        );
       this.index += 1;
       this.lastDecision = now;
     }


### PR DESCRIPTION
## Summary
- ge varje strategi ett favoritavstånd som minskar från 300 till 200
- AI:n rör sig mot favoritavståndet eller 200 när motståndarens hälsa är låg
- ringdomaren återställer boxarna och visar "BREAK" om de kommer närmare än 100

## Testing
- `npm test` *(misslyckas: package.json saknas)*

------
https://chatgpt.com/codex/tasks/task_e_68920c40c1e0832ab35bf3a9eca6af05