### PR TITLE
feat: smooth block and smarter AI

### DIFF
--- a/src/scripts/ai-strategies.js
+++ b/src/scripts/ai-strategies.js
@@ -27,9 +27,14 @@ function generateStrategy(level) {
   const blockProb = Math.max(0.7 - 0.05 * level, 0.1);
   const jabProb = Math.min(0.05 * level, 0.5);
   const upperProb = Math.min(0.02 * level, 0.25);
+  const noneProb = Math.max(0.6 - 0.05 * level, 0.05);
 
   const actions = [];
   for (let i = 0; i < 180; i++) {
+    if (Math.random() < noneProb) {
+      actions.push({ none: true });
+      continue;
+    }
     const act = {
       forward: false,
       back: false,

--- a/src/scripts/strategy-ai-controller.js
+++ b/src/scripts/strategy-ai-controller.js
@@ -1,6 +1,7 @@
 import { STRATEGIES, createBaseActions } from './ai-strategies.js';
 
 function convertAction(action, boxer, opponent, preferredDistance) {
+  if (action.none) return createBaseActions();
   const res = createBaseActions();
   if (action.block) res.block = true;
   if (action.jabLeft) res.jabLeft = true;
@@ -8,7 +9,12 @@ function convertAction(action, boxer, opponent, preferredDistance) {
   if (action.uppercut) res.uppercut = true;
 
   const isAttacking = action.jabLeft || action.jabRight || action.uppercut;
+  const isBlocking = action.block;
   const currentDist = Math.abs(boxer.sprite.x - opponent.sprite.x);
+
+  if (currentDist > 350 && (isAttacking || isBlocking)) {
+    return createBaseActions();
+  }
 
   if (isAttacking) {
     if (action.forward && currentDist > 200) {


### PR DESCRIPTION
## Summary
- add 120ms debounce for block input
- block only triggers if no attack or movement is active
- AI strategies sometimes pick no-action and skip block/punch if too far away

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689210c750b8832aa4734cac585ce976