### PR TITLE
Allow boxers to cross and trigger break after proximity

### DIFF
--- a/src/scripts/boxer.js
+++ b/src/scripts/boxer.js
@@ -128,20 +128,6 @@ export class Boxer {
     );
   }
 
-  preventOverlap(opponent) {
-    const minDist =
-      (this.sprite.displayWidth + opponent.sprite.displayWidth) / 2;
-    if (this.prefix === BOXER_PREFIXES.P1) {
-      if (this.sprite.x > opponent.sprite.x - minDist) {
-        this.sprite.x = opponent.sprite.x - minDist;
-      }
-    } else {
-      if (this.sprite.x < opponent.sprite.x + minDist) {
-        this.sprite.x = opponent.sprite.x + minDist;
-      }
-    }
-  }
-
   triggerKO() {
     this.sprite.removeAllListeners('animationcomplete');
     this.sprite.play(animKey(this.prefix, 'ko'));
@@ -341,7 +327,6 @@ export class Boxer {
       (actions.moveRight && this.facingRight) ||
       (actions.moveLeft && !this.facingRight);
     if (movingForward) this.adjustStamina(-0.0003);
-    this.preventOverlap(opponent);
     this.applyBounds();
   }
 

--- a/src/scripts/match-scene.js
+++ b/src/scripts/match-scene.js
@@ -80,6 +80,7 @@ export class MatchScene extends Phaser.Scene {
     this.matchOver = false;
 
     this.breaking = false;
+    this.closeTime = null;
     this.breakText = this.add
       .text(width / 2, height / 2, 'BREAK', {
         font: '64px Arial',
@@ -107,16 +108,28 @@ export class MatchScene extends Phaser.Scene {
   }
 
   update(time, delta) {
-    const distance = Phaser.Math.Distance.Between(
+    const rawDistance = Phaser.Math.Distance.Between(
       this.player1.sprite.x,
       this.player1.sprite.y,
       this.player2.sprite.x,
       this.player2.sprite.y
     );
+    const distance =
+      this.player1.sprite.x < this.player2.sprite.x
+        ? rawDistance
+        : -rawDistance;
 
-    if (!this.breaking && distance < 100) {
-      this.resetBoxers();
-      this.showBreak();
+    if (!this.breaking) {
+      if (Math.abs(distance) < 50) {
+        if (this.closeTime === null) this.closeTime = time;
+        else if (time - this.closeTime >= 5000) {
+          this.resetBoxers();
+          this.showBreak();
+          this.closeTime = null;
+        }
+      } else {
+        this.closeTime = null;
+      }
     }
     const action1 = this.player1.lastAction;
     const action2 = this.player2.lastAction;


### PR DESCRIPTION
## Summary
- Remove rigid overlap constraint so fighters can cross the ring
- Track signed distance and initiate break if fighters stay within 50 units for 5 seconds

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68921413c010832abfc3493329de2fe3