### PR TITLE
feat: improve ai distance handling

### DIFF
--- a/src/scripts/boxer.js
+++ b/src/scripts/boxer.js
@@ -401,7 +401,7 @@ export class Boxer {
 
     const oppTired = opponent.stamina < opponent.maxStamina / 3;
     if (oppTired && !this.opponentWasTired && !tired) {
-      if (this.controller.shiftLevel) this.controller.shiftLevel(1);
+      if (this.controller.shiftLevel) this.controller.shiftLevel(2);
       this.opponentWasTired = true;
     }
     if (!oppTired) this.opponentWasTired = false;

--- a/src/scripts/strategy-ai-controller.js
+++ b/src/scripts/strategy-ai-controller.js
@@ -47,6 +47,11 @@ export class StrategyAIController {
     this.lastDecision = 0;
     this.decisionInterval = 500; // ms per round second
     this.cached = createBaseActions();
+    this.retreating = false;
+    this.lastRetreat = 0;
+    this.idleSeeking = false;
+    this.lastIdleSeek = 0;
+    this.lastMove = Date.now();
   }
 
   getLevel() {
@@ -63,18 +68,62 @@ export class StrategyAIController {
 
   getActions(boxer, opponent) {
     const now = Date.now();
+    const strategy = STRATEGIES[this.level - 1];
     if (now - this.lastDecision > this.decisionInterval) {
-        const strategy = STRATEGIES[this.level - 1];
-        const action = strategy.actions[this.index % strategy.actions.length];
-        this.cached = convertAction(
-          action,
-          boxer,
-          opponent,
-          strategy.distance
-        );
+      const action = strategy.actions[this.index % strategy.actions.length];
+      this.cached = convertAction(
+        action,
+        boxer,
+        opponent,
+        strategy.distance
+      );
       this.index += 1;
       this.lastDecision = now;
     }
+
+    const dist = Math.abs(boxer.sprite.x - opponent.sprite.x);
+
+    if (this.cached.moveLeft || this.cached.moveRight) {
+      this.lastMove = now;
+    }
+
+    if (this.retreating) {
+      if (dist < strategy.distance) {
+        const forced = createBaseActions();
+        if (boxer.sprite.x < opponent.sprite.x) forced.moveLeft = true;
+        else forced.moveRight = true;
+        this.cached = forced;
+        this.lastMove = now;
+      } else {
+        this.retreating = false;
+        this.lastRetreat = now;
+      }
+    } else if (dist < 50 && now - this.lastRetreat > 10000) {
+      this.retreating = true;
+    } else if (!this.idleSeeking) {
+      if (now - this.lastMove > 5000 && now - this.lastIdleSeek > 10000) {
+        this.idleSeeking = true;
+      }
+    }
+
+    if (this.idleSeeking && !this.retreating) {
+      if (Math.abs(dist - strategy.distance) > 10) {
+        const forced = createBaseActions();
+        if (dist < strategy.distance) {
+          if (boxer.sprite.x < opponent.sprite.x) forced.moveLeft = true;
+          else forced.moveRight = true;
+        } else {
+          if (boxer.sprite.x < opponent.sprite.x) forced.moveRight = true;
+          else forced.moveLeft = true;
+        }
+        this.cached = forced;
+        this.lastMove = now;
+      } else {
+        this.idleSeeking = false;
+        this.lastIdleSeek = now;
+      }
+    }
+
     return this.cached;
   }
 }


### PR DESCRIPTION
## Summary
- make AI retreat to preferred distance when too close with cooldown
- add idle distance correction after standing still
- boost strategy shift when opponent tired for more aggression

## Testing
- `npm test` *(fails: could not find package.json)*
- `node --check src/scripts/strategy-ai-controller.js`
- `node --check src/scripts/boxer.js`


------
https://chatgpt.com/codex/tasks/task_e_689218bd5320832abd7217e5816b01f6