### PR TITLE
Introduce rule manager for strategy adjustments

### DIFF
--- a/src/scripts/match-scene.js
+++ b/src/scripts/match-scene.js
@@ -5,6 +5,7 @@ import { eventBus } from './event-bus.js';
 import { RoundTimer } from './round-timer.js';
 import { HealthManager } from './health-manager.js';
 import { BOXER_PREFIXES, animKey } from './helpers.js';
+import { RuleManager } from './rule-manager.js';
 
 export class MatchScene extends Phaser.Scene {
   constructor() {
@@ -65,6 +66,9 @@ export class MatchScene extends Phaser.Scene {
 
     this.healthManager = new HealthManager(this.player1, this.player2);
     this.roundTimer = new RoundTimer(this);
+    this.ruleManager = new RuleManager(this.player1, this.player2);
+    this.roundLength = 180;
+    this.lastSecond = -1;
     eventBus.on('round-ended', (round) => this.endRound(round));
     this.events.once(Phaser.Scenes.Events.SHUTDOWN, () => {
       eventBus.off('round-ended');
@@ -144,6 +148,12 @@ export class MatchScene extends Phaser.Scene {
       statsLine,
       strategyLine,
     ]);
+
+    const currentSecond = this.roundLength - this.roundTimer.remaining;
+    if (currentSecond !== this.lastSecond && currentSecond < this.roundLength) {
+      this.ruleManager.evaluate(currentSecond);
+      this.lastSecond = currentSecond;
+    }
 
     if (this.paused) return;
 

--- a/src/scripts/rule-manager.js
+++ b/src/scripts/rule-manager.js
@@ -1,0 +1,106 @@
+import { STRATEGIES } from './ai-strategies.js';
+
+export class RuleManager {
+  constructor(boxer1, boxer2) {
+    this.b1 = boxer1;
+    this.b2 = boxer2;
+    this.activeRule = null;
+    this.activeUntil = 0;
+  }
+
+  fill(actions, start, seq) {
+    for (let i = 0; i < seq.length; i++) {
+      const idx = start + i;
+      if (idx >= 0 && idx < actions.length) {
+        actions[idx] = seq[i];
+      }
+    }
+  }
+
+  evaluate(currentSecond) {
+    if (this.activeRule && currentSecond < this.activeUntil) {
+      return;
+    }
+    if (this.activeRule && currentSecond >= this.activeUntil) {
+      this.activeRule = null;
+    }
+
+    if (this.activeRule) return;
+
+    const tired1 = this.b1.stamina / this.b1.maxStamina < 0.3;
+    const tired2 = this.b2.stamina / this.b2.maxStamina < 0.3;
+    const dist = Math.abs(this.b1.sprite.x - this.b2.sprite.x);
+
+    if (tired1 && tired2) {
+      const a1 = STRATEGIES[this.b1.controller.getLevel() - 1].actions;
+      const a2 = STRATEGIES[this.b2.controller.getLevel() - 1].actions;
+      const seq = [{ back: true }, { back: true }];
+      this.fill(a1, currentSecond, seq);
+      this.fill(a2, currentSecond, seq);
+      this.activeRule = 'both-tired';
+      this.activeUntil = currentSecond + seq.length;
+      return;
+    }
+
+    if (tired1 && !tired2) {
+      this.b1.controller.shiftLevel(-1);
+      this.b2.controller.shiftLevel(2);
+      const a1 = STRATEGIES[this.b1.controller.getLevel() - 1].actions;
+      const a2 = STRATEGIES[this.b2.controller.getLevel() - 1].actions;
+      this.fill(a1, currentSecond, [
+        { back: true },
+        { back: true },
+        { block: true },
+      ]);
+      this.fill(a2, currentSecond, [
+        { forward: true },
+        { forward: true },
+        { uppercut: true },
+      ]);
+      this.activeRule = 'p1-tired';
+      this.activeUntil = currentSecond + 3;
+      return;
+    }
+
+    if (!tired1 && tired2) {
+      this.b2.controller.shiftLevel(-1);
+      this.b1.controller.shiftLevel(2);
+      const a1 = STRATEGIES[this.b1.controller.getLevel() - 1].actions;
+      const a2 = STRATEGIES[this.b2.controller.getLevel() - 1].actions;
+      this.fill(a2, currentSecond, [
+        { back: true },
+        { back: true },
+        { block: true },
+      ]);
+      this.fill(a1, currentSecond, [
+        { forward: true },
+        { forward: true },
+        { uppercut: true },
+      ]);
+      this.activeRule = 'p2-tired';
+      this.activeUntil = currentSecond + 3;
+      return;
+    }
+
+    if (dist < 50) {
+      const h1 = this.b1.health / this.b1.maxHealth;
+      const h2 = this.b2.health / this.b2.maxHealth;
+      const a1 = STRATEGIES[this.b1.controller.getLevel() - 1].actions;
+      const a2 = STRATEGIES[this.b2.controller.getLevel() - 1].actions;
+      if (h1 === h2) {
+        const seq = [{ back: true }, { back: true }];
+        this.fill(a1, currentSecond, seq);
+        this.fill(a2, currentSecond, seq);
+      } else if (h1 < h2) {
+        this.fill(a1, currentSecond, [{ back: true }, { back: true }]);
+        this.fill(a2, currentSecond, [{ none: true }, { none: true }]);
+      } else {
+        this.fill(a2, currentSecond, [{ back: true }, { back: true }]);
+        this.fill(a1, currentSecond, [{ none: true }, { none: true }]);
+      }
+      this.activeRule = 'close-distance';
+      this.activeUntil = currentSecond + 2;
+    }
+  }
+}
+


### PR DESCRIPTION
## Summary
- add `RuleManager` to enforce stamina and distance based rules on boxer strategies
- hook rule evaluation into `MatchScene` each second of the round

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689271773430832a9f6ae422498f8e01