### PR TITLE
Remove unused distance property from AI strategies

### DIFF
--- a/src/scripts/ai-strategies.js
+++ b/src/scripts/ai-strategies.js
@@ -60,7 +60,6 @@ function generateStrategy(level) {
 }
 
 export const STRATEGIES = Array.from({ length: 10 }, (_, i) => ({
-  distance: 300 - i * 10,
   actions: generateStrategy(i + 1),
 }));
 


### PR DESCRIPTION
## Summary
- drop obsolete `distance` field from AI STRATEGIES definitions

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6893269b3300832a81a6e84edd5805ca