### PR TITLE
Avoid repeated actions per round second and stabilize block animation

### DIFF
--- a/src/scripts/animation-factory.js
+++ b/src/scripts/animation-factory.js
@@ -4,7 +4,7 @@ export const ANIM_DEFS = {
   idle: { frameCount: 10, repeat: -1 },
   forward: { frameCount: 10, repeat: -1 },
   backward: { frameCount: 10, repeat: -1 },
-  block: { frameCount: 10, repeat: -1 },
+  block: { frameCount: 10, repeat: 0 },
   jabRight: { frameCount: 8, repeat: 0 },
   jabLeft: { frameCount: 8, repeat: 0 },
   uppercut: { frameCount: 8, repeat: 0 },

--- a/src/scripts/match-scene.js
+++ b/src/scripts/match-scene.js
@@ -157,8 +157,8 @@ export class MatchScene extends Phaser.Scene {
 
     if (this.paused) return;
 
-    this.player1.update(delta, this.player2);
-    this.player2.update(delta, this.player1);
+    this.player1.update(delta, this.player2, currentSecond);
+    this.player2.update(delta, this.player1, currentSecond);
 
     this.handleHit(this.player1, this.player2, 'p2');
     this.handleHit(this.player2, this.player1, 'p1');

--- a/src/scripts/strategy-ai-controller.js
+++ b/src/scripts/strategy-ai-controller.js
@@ -22,8 +22,7 @@ export class StrategyAIController {
   constructor(level = 1) {
     this.level = Phaser.Math.Clamp(level, 1, 10);
     this.index = 0;
-    this.lastDecision = 0;
-    this.decisionInterval = 500; // ms per round second
+    this.lastDecision = -1;
     this.cached = createBaseActions();
   }
 
@@ -39,14 +38,13 @@ export class StrategyAIController {
     this.setLevel(this.level + delta);
   }
 
-  getActions(boxer, opponent) {
-    const now = Date.now();
+  getActions(boxer, opponent, currentSecond) {
     const strategy = STRATEGIES[this.level - 1];
-    if (now - this.lastDecision > this.decisionInterval) {
+    if (currentSecond !== this.lastDecision) {
       const action = strategy.actions[this.index % strategy.actions.length];
       this.cached = convertAction(action, boxer, opponent);
       this.index += 1;
-      this.lastDecision = now;
+      this.lastDecision = currentSecond;
     }
     return this.cached;
   }


### PR DESCRIPTION
## Summary
- Prevent AI from issuing the same action multiple times within a round second
- Stop block animation on the final frame and keep guard raised on consecutive blocks
- Pass round timer seconds to boxers so each second's action runs once

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689336196cf4832aa03201cd5ee70d10