### PR TITLE
Double boxer movement speed

### DIFF
--- a/src/scripts/boxer.js
+++ b/src/scripts/boxer.js
@@ -37,7 +37,7 @@ export class Boxer {
     this.prefix = prefix;
     this.controller = controller;
     this.stats = stats;
-    this.speed = 200 * (stats.speed || 1);
+    this.speed = 400 * (stats.speed || 1);
     this.power = stats.power || 1;
     this.maxPower = this.power;
     this.stamina = stats.stamina || 1;


### PR DESCRIPTION
## Summary
- double base movement speed for boxers so they move faster per round second

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68934f05e59c832a94770d70c40461e8