### PR TITLE
Add AI opponent selection with strategy and keyboard player

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,33 +1,35 @@
 # The Boxer
 
 A small boxing game built with Phaser. Two boxers are displayed in the ring.
-Each boxer is controlled by a controller object. The current setup uses a
-keyboard controller for both boxers so you can play locally with two sets of
-keys. Because the behaviour is abstracted through controllers it is trivial to
-swap a boxer to a programmatic or AI driven controller in the future.
+Each boxer is controlled by a controller object. When the game starts you first
+select the boxer you will control with the keyboard, then choose an opponent
+that is steered by the computer along with its opening strategy. Because the
+behaviour is abstracted through controllers it is trivial to swap a boxer to a
+different type of controller in the future.
 
 ## Keyboard Controls
 
-The table below lists the keys used to control each boxer.
+The table below lists the keys used to control the player boxer. The opponent
+is controlled by the AI and has no keyboard controls.
 
-| Action | Player 1 | Player 2 |
-|-------|---------|---------|
-| Move left | Left Arrow | `A` |
-| Move right | Right Arrow | `D` |
-| Move up | Up Arrow | `W` |
-| Move down | Down Arrow | `S` |
-| Turn left | `Shift` + Left Arrow | `Shift` + `A` |
-| Turn right | `Shift` + Right Arrow | `Shift` + `D` |
-| Block | Numpad 5 | `X` |
-| Jab right | Page Down | `E` |
-| Jab left | Delete | `Q` |
-| Uppercut | Numpad 0 | `F` |
-| Hurt 1 | `1` | `4` |
-| Hurt 2 | `2` | `5` |
-| Dizzy | `3` | `6` |
-| Idle | `7` | `8` |
-| KO | Numpad 8 | `G` |
-| Win | `0` | `+` |
+| Action | Player |
+|-------|-------|
+| Move left | Left Arrow |
+| Move right | Right Arrow |
+| Move up | Up Arrow |
+| Move down | Down Arrow |
+| Turn left | `Shift` + Left Arrow |
+| Turn right | `Shift` + Right Arrow |
+| Block | Numpad 5 |
+| Jab right | Page Down |
+| Jab left | Delete |
+| Uppercut | Numpad 0 |
+| Hurt 1 | `1` |
+| Hurt 2 | `2` |
+| Dizzy | `3` |
+| Idle | `7` |
+| KO | Numpad 8 |
+| Win | `0` |
 
 Press `Shift` + `P` to pause the match.
 

--- a/src/scripts/match-scene.js
+++ b/src/scripts/match-scene.js
@@ -1,5 +1,6 @@
 import { Boxer } from './boxer.js';
 import { StrategyAIController } from './strategy-ai-controller.js';
+import { KeyboardController } from './controllers.js';
 import { createBoxerAnimations } from './animation-factory.js';
 import { eventBus } from './event-bus.js';
 import { RoundTimer } from './round-timer.js';
@@ -26,11 +27,20 @@ export class MatchScene extends Phaser.Scene {
     createBoxerAnimations(this, BOXER_PREFIXES.P1);
     createBoxerAnimations(this, BOXER_PREFIXES.P2);
 
-    // AI controllers using offensive level strategies
-    const controller1 = new StrategyAIController(4);
-    const controller2 = new StrategyAIController(6);
-    // Example of switching strategy during the match:
-    // controller1.setLevel(5);
+    // Player 1 uses keyboard, player 2 uses AI strategy
+    const controller1 = new KeyboardController(this, {
+      block: 'NUMPAD_FIVE',
+      jabRight: 'PAGEDOWN',
+      jabLeft: 'DELETE',
+      uppercut: 'NUMPAD_ZERO',
+      hurt1: 'ONE',
+      hurt2: 'TWO',
+      dizzy: 'THREE',
+      idle: 'SEVEN',
+      ko: 'NUMPAD_EIGHT',
+      win: 'ZERO',
+    });
+    const controller2 = new StrategyAIController(data?.aiLevel || 1);
 
     const centerX = width / 2;
     const centerY = height / 2;
@@ -140,8 +150,10 @@ export class MatchScene extends Phaser.Scene {
     const statsLine =
       `P1 S:${this.player1.stamina.toFixed(2)} H:${this.player1.health.toFixed(2)} P:${this.player1.power.toFixed(2)} | ` +
       `P2 S:${this.player2.stamina.toFixed(2)} H:${this.player2.health.toFixed(2)} P:${this.player2.power.toFixed(2)}`;
+    const getLevel = (ctrl) =>
+      typeof ctrl.getLevel === 'function' ? ctrl.getLevel() : 'N/A';
     const strategyLine =
-      `Strategi: P1 ${this.player1.controller.getLevel()} | P2 ${this.player2.controller.getLevel()}`;
+      `Strategi: P1 ${getLevel(this.player1.controller)} | P2 ${getLevel(this.player2.controller)}`;
     this.debugText.setText([
       `Distans: ${distance.toFixed(1)}`,
       `P1: ${action1} | P2: ${action2}`,

--- a/src/scripts/select-boxer-scene.js
+++ b/src/scripts/select-boxer-scene.js
@@ -5,6 +5,7 @@ export class SelectBoxerScene extends Phaser.Scene {
     super('SelectBoxer');
     this.step = 1;
     this.choice = [];
+    this.options = [];
   }
 
   create() {
@@ -15,7 +16,11 @@ export class SelectBoxerScene extends Phaser.Scene {
         color: '#ffffff',
       })
       .setOrigin(0.5, 0);
+    this.showBoxerOptions();
+  }
 
+  showBoxerOptions() {
+    this.clearOptions();
     BOXERS.forEach((b, i) => {
       const y = 60 + i * 30;
       const txt = this.add.text(50, y, `${b.name} (${b.country})`, {
@@ -23,19 +28,45 @@ export class SelectBoxerScene extends Phaser.Scene {
         color: '#ffffff',
       });
       txt.setInteractive({ useHandCursor: true });
-      txt.on('pointerdown', () => this.select(i));
+      txt.on('pointerdown', () => this.selectBoxer(i));
+      this.options.push(txt);
     });
   }
 
-  select(index) {
+  showStrategyOptions() {
+    this.clearOptions();
+    for (let i = 1; i <= 10; i++) {
+      const y = 60 + i * 30;
+      const txt = this.add.text(50, y, `Strategi ${i}`, {
+        font: '20px Arial',
+        color: '#ffffff',
+      });
+      txt.setInteractive({ useHandCursor: true });
+      txt.on('pointerdown', () => this.startMatch(i));
+      this.options.push(txt);
+    }
+  }
+
+  clearOptions() {
+    this.options.forEach((o) => o.destroy());
+    this.options = [];
+  }
+
+  selectBoxer(index) {
     this.choice.push(BOXERS[index]);
     if (this.step === 1) {
       this.step = 2;
       this.instruction.setText('Välj Boxer 2');
-    } else {
-      const [boxer1, boxer2] = this.choice;
-      this.scene.launch('OverlayUI');
-      this.scene.start('Match', { boxer1, boxer2 });
+    } else if (this.step === 2) {
+      this.step = 3;
+      this.instruction.setText('Välj Strategi');
+      this.showStrategyOptions();
     }
+  }
+
+  startMatch(level) {
+    const [boxer1, boxer2] = this.choice;
+    this.scene.launch('OverlayUI');
+    this.scene.start('Match', { boxer1, boxer2, aiLevel: level });
   }
 }


### PR DESCRIPTION
## Summary
- Allow selecting first player's boxer, opponent boxer, and AI strategy before starting the match
- Use keyboard controls for player boxer and chosen AI strategy for opponent
- Document new startup flow and single-player controls

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68936c767660832aa934b5a3dc9f00a5