### PR TITLE
Add summary confirmation before starting match

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,10 @@
 A small boxing game built with Phaser. Two boxers are displayed in the ring.
 Each boxer is controlled by a controller object. When the game starts you first
 select the boxer you will control with the keyboard, then choose an opponent
-that is steered by the computer along with its opening strategy. Because the
-behaviour is abstracted through controllers it is trivial to swap a boxer to a
-different type of controller in the future.
+that is steered by the computer along with its opening strategy. After picking
+a strategy you will be shown a summary of the match setup where you can confirm
+or cancel your choices. Because the behaviour is abstracted through controllers
+it is trivial to swap a boxer to a different type of controller in the future.
 
 ## Keyboard Controls
 

--- a/src/scripts/select-boxer-scene.js
+++ b/src/scripts/select-boxer-scene.js
@@ -6,12 +6,13 @@ export class SelectBoxerScene extends Phaser.Scene {
     this.step = 1;
     this.choice = [];
     this.options = [];
+    this.selectedStrategy = null;
   }
 
   create() {
     const width = this.sys.game.config.width;
     this.instruction = this.add
-      .text(width / 2, 20, 'Välj Boxer 1', {
+      .text(width / 2, 20, 'Välj din boxer', {
         font: '24px Arial',
         color: '#ffffff',
       })
@@ -42,7 +43,7 @@ export class SelectBoxerScene extends Phaser.Scene {
         color: '#ffffff',
       });
       txt.setInteractive({ useHandCursor: true });
-      txt.on('pointerdown', () => this.startMatch(i));
+      txt.on('pointerdown', () => this.selectStrategy(i));
       this.options.push(txt);
     }
   }
@@ -56,17 +57,72 @@ export class SelectBoxerScene extends Phaser.Scene {
     this.choice.push(BOXERS[index]);
     if (this.step === 1) {
       this.step = 2;
-      this.instruction.setText('Välj Boxer 2');
+      this.instruction.setText('Välj din motståndare');
     } else if (this.step === 2) {
       this.step = 3;
-      this.instruction.setText('Välj Strategi');
+      this.instruction.setText('Välj motståndarens strategi');
       this.showStrategyOptions();
     }
   }
 
-  startMatch(level) {
+  selectStrategy(level) {
+    this.selectedStrategy = level;
+    this.showSummary();
+  }
+
+  showSummary() {
+    this.clearOptions();
+    const width = this.sys.game.config.width;
+    const [player, opponent] = this.choice;
+    this.instruction.setText('Sammanfattning');
+
+    const summaryText = `Du: ${player.name}\nMotståndare: ${opponent.name}\nStrategi: ${this.selectedStrategy}`;
+    const summary = this.add
+      .text(width / 2, 80, summaryText, {
+        font: '20px Arial',
+        color: '#ffffff',
+        align: 'center',
+      })
+      .setOrigin(0.5, 0);
+    this.options.push(summary);
+
+    const okBtn = this.add
+      .text(width / 2 - 60, 200, 'OK', {
+        font: '20px Arial',
+        color: '#00ff00',
+      })
+      .setOrigin(0.5, 0)
+      .setInteractive({ useHandCursor: true });
+    okBtn.on('pointerdown', () => this.startMatch());
+
+    const cancelBtn = this.add
+      .text(width / 2 + 60, 200, 'Cancel', {
+        font: '20px Arial',
+        color: '#ff0000',
+      })
+      .setOrigin(0.5, 0)
+      .setInteractive({ useHandCursor: true });
+    cancelBtn.on('pointerdown', () => this.resetSelection());
+
+    this.options.push(okBtn, cancelBtn);
+  }
+
+  resetSelection() {
+    this.clearOptions();
+    this.choice = [];
+    this.step = 1;
+    this.selectedStrategy = null;
+    this.instruction.setText('Välj din boxer');
+    this.showBoxerOptions();
+  }
+
+  startMatch() {
     const [boxer1, boxer2] = this.choice;
     this.scene.launch('OverlayUI');
-    this.scene.start('Match', { boxer1, boxer2, aiLevel: level });
+    this.scene.start('Match', {
+      boxer1,
+      boxer2,
+      aiLevel: this.selectedStrategy,
+    });
   }
 }


### PR DESCRIPTION
## Summary
- Clarify selection flow so the first boxer is the player and the second is the opponent.
- Add confirmation summary with OK/Cancel after choosing opponent strategy.
- Document match setup confirmation step in README.

## Testing
- `npm test` *(fails: Could not read package.json)*
- `npm run lint` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68936fe5e52c832abf0620cbc6dcab76