### PR TITLE
Start match correctly with English diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,15 +36,15 @@ Press `Shift` + `P` to pause the match.
 
 ## Available Boxers
 
-| Namn | Land | Stamina | Power | Health | Speed |
+| Name | Country | Stamina | Power | Health | Speed |
 |------|------|---------|-------|--------|-------|
-| Glass Joe | Frankrike | 1.0 | 1.0 | 1.0 | 1.0 |
-| Von Kaiser | Tyskland | 1.2 | 1.2 | 1.0 | 1.0 |
+| Glass Joe | France | 1.0 | 1.0 | 1.0 | 1.0 |
+| Von Kaiser | Germany | 1.2 | 1.2 | 1.0 | 1.0 |
 | Piston Honda | Japan | 1.3 | 1.3 | 1.2 | 1.0 |
-| Don Flamenco | Spanien | 1.3 | 1.5 | 1.0 | 1.2 |
+| Don Flamenco | Spain | 1.3 | 1.5 | 1.0 | 1.2 |
 | King Hippo | Hippo Island | 1.0 | 1.6 | 1.8 | 1.0 |
-| Great Tiger | Indien | 1.4 | 1.0 | 1.0 | 1.5 |
-| Bald Bull | Turkiet | 1.5 | 2.0 | 2.0 | 1.2 |
-| Soda Popinski | Ryssland | 1.0 | 2.0 | 1.5 | 2.0 |
+| Great Tiger | India | 1.4 | 1.0 | 1.0 | 1.5 |
+| Bald Bull | Turkey | 1.5 | 2.0 | 2.0 | 1.2 |
+| Soda Popinski | Russia | 1.0 | 2.0 | 1.5 | 2.0 |
 | Mr. Sandman | USA | 2.0 | 2.0 | 2.0 | 2.0 |
 | Mike Tyson | USA | 2.5 | 2.5 | 2.2 | 2.5 |

--- a/src/scripts/boxer-data.js
+++ b/src/scripts/boxer-data.js
@@ -1,7 +1,7 @@
 export const BOXERS = [
   {
     name: 'Glass Joe',
-    country: 'Frankrike',
+    country: 'France',
     stamina: 1.0,
     power: 1.0,
     health: 1.0,
@@ -9,7 +9,7 @@ export const BOXERS = [
   },
   {
     name: 'Von Kaiser',
-    country: 'Tyskland',
+    country: 'Germany',
     stamina: 1.2,
     power: 1.2,
     health: 1.0,
@@ -25,7 +25,7 @@ export const BOXERS = [
   },
   {
     name: 'Don Flamenco',
-    country: 'Spanien',
+    country: 'Spain',
     stamina: 1.3,
     power: 1.5,
     health: 1.0,
@@ -41,7 +41,7 @@ export const BOXERS = [
   },
   {
     name: 'Great Tiger',
-    country: 'Indien',
+    country: 'India',
     stamina: 1.4,
     power: 1.0,
     health: 1.0,
@@ -49,7 +49,7 @@ export const BOXERS = [
   },
   {
     name: 'Bald Bull',
-    country: 'Turkiet',
+    country: 'Turkey',
     stamina: 1.5,
     power: 2.0,
     health: 2.0,
@@ -57,7 +57,7 @@ export const BOXERS = [
   },
   {
     name: 'Soda Popinski',
-    country: 'Ryssland',
+    country: 'Russia',
     stamina: 1.0,
     power: 2.0,
     health: 1.5,

--- a/src/scripts/match-scene.js
+++ b/src/scripts/match-scene.js
@@ -150,15 +150,19 @@ export class MatchScene extends Phaser.Scene {
     const statsLine =
       `P1 S:${this.player1.stamina.toFixed(2)} H:${this.player1.health.toFixed(2)} P:${this.player1.power.toFixed(2)} | ` +
       `P2 S:${this.player2.stamina.toFixed(2)} H:${this.player2.health.toFixed(2)} P:${this.player2.power.toFixed(2)}`;
-    const getLevel = (ctrl) =>
-      typeof ctrl.getLevel === 'function' ? ctrl.getLevel() : 'N/A';
+    const getStrategy = (ctrl) =>
+      ctrl instanceof KeyboardController
+        ? 'human player'
+        : ctrl.getLevel();
     const strategyLine =
-      `Strategi: P1 ${getLevel(this.player1.controller)} | P2 ${getLevel(this.player2.controller)}`;
+      `Strategy: P1 ${getStrategy(this.player1.controller)} | P2 ${getStrategy(this.player2.controller)}`;
+    const ruleLine = `Rule: ${this.ruleManager.activeRule || 'none'}`;
     this.debugText.setText([
-      `Distans: ${distance.toFixed(1)}`,
+      `Distance: ${distance.toFixed(1)}`,
       `P1: ${action1} | P2: ${action2}`,
       statsLine,
       strategyLine,
+      ruleLine,
     ]);
 
     const currentSecond = this.roundLength - this.roundTimer.remaining;

--- a/src/scripts/overlay.js
+++ b/src/scripts/overlay.js
@@ -99,7 +99,7 @@ export class OverlayUI extends Phaser.Scene {
 
   showRound(number) {
     if (!this.roundText) return;
-    this.roundText.setText(`Rond ${number}`);
+    this.roundText.setText(`Round ${number}`);
   }
 
   setNames(p1, p2) {
@@ -116,7 +116,7 @@ export class OverlayUI extends Phaser.Scene {
 
   announceWinner(name) {
     if (this.roundText) {
-      this.roundText.setText(`${name} vinner på KO!`);
+      this.roundText.setText(`${name} wins by KO!`);
     }
   }
 }

--- a/src/scripts/select-boxer-scene.js
+++ b/src/scripts/select-boxer-scene.js
@@ -12,7 +12,7 @@ export class SelectBoxerScene extends Phaser.Scene {
   create() {
     const width = this.sys.game.config.width;
     this.instruction = this.add
-      .text(width / 2, 20, 'Välj din boxer', {
+      .text(width / 2, 20, 'Choose your boxer', {
         font: '24px Arial',
         color: '#ffffff',
       })
@@ -38,7 +38,7 @@ export class SelectBoxerScene extends Phaser.Scene {
     this.clearOptions();
     for (let i = 1; i <= 10; i++) {
       const y = 60 + i * 30;
-      const txt = this.add.text(50, y, `Strategi ${i}`, {
+      const txt = this.add.text(50, y, `Strategy ${i}`, {
         font: '20px Arial',
         color: '#ffffff',
       });
@@ -57,10 +57,10 @@ export class SelectBoxerScene extends Phaser.Scene {
     this.choice.push(BOXERS[index]);
     if (this.step === 1) {
       this.step = 2;
-      this.instruction.setText('Välj din motståndare');
+      this.instruction.setText('Choose your opponent');
     } else if (this.step === 2) {
       this.step = 3;
-      this.instruction.setText('Välj motståndarens strategi');
+      this.instruction.setText("Choose the opponent's strategy");
       this.showStrategyOptions();
     }
   }
@@ -74,9 +74,11 @@ export class SelectBoxerScene extends Phaser.Scene {
     this.clearOptions();
     const width = this.sys.game.config.width;
     const [player, opponent] = this.choice;
-    this.instruction.setText('Sammanfattning');
+    this.instruction.setText('Summary');
 
-    const summaryText = `Du: ${player.name}\nMotståndare: ${opponent.name}\nStrategi: ${this.selectedStrategy}`;
+    const summaryText = `You: ${player.name}
+Opponent: ${opponent.name}
+Strategy: ${this.selectedStrategy}`;
     const summary = this.add
       .text(width / 2, 80, summaryText, {
         font: '20px Arial',
@@ -112,17 +114,18 @@ export class SelectBoxerScene extends Phaser.Scene {
     this.choice = [];
     this.step = 1;
     this.selectedStrategy = null;
-    this.instruction.setText('Välj din boxer');
+    this.instruction.setText('Choose your boxer');
     this.showBoxerOptions();
   }
 
   startMatch() {
     const [boxer1, boxer2] = this.choice;
+    const aiLevel = this.selectedStrategy ?? 1;
     this.scene.launch('OverlayUI');
     this.scene.start('Match', {
       boxer1,
       boxer2,
-      aiLevel: this.selectedStrategy,
+      aiLevel,
     });
   }
 }


### PR DESCRIPTION
## Summary
- Translate interface text and boxer data to English
- Ensure match starts and report active AI rule with strategy diagnostics
- Show "human player" when boxer is controlled by keyboard

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6893727ecb60832abc36f3477fccbbb9