### PR TITLE
Fix unresponsive summary buttons

### DIFF
--- a/src/scripts/select-boxer-scene.js
+++ b/src/scripts/select-boxer-scene.js
@@ -67,7 +67,13 @@ export class SelectBoxerScene extends Phaser.Scene {
 
   selectStrategy(level) {
     this.selectedStrategy = level;
-    this.showSummary();
+    // Defer showing the summary until the pointer is released.
+    // Destroying interactive objects during their pointerdown handler
+    // can leave the input system in an inconsistent state, which makes
+    // subsequent buttons (like OK/Cancel) unresponsive. Waiting for the
+    // pointerup event ensures the previous interaction completes before
+    // clearing the options and adding new interactive elements.
+    this.input.once('pointerup', () => this.showSummary());
   }
 
   showSummary() {


### PR DESCRIPTION
## Summary
- Ensure summary is shown after pointerup to avoid breaking input

## Testing
- `npm test` (fails: ENOENT, no package.json)


------
https://chatgpt.com/codex/tasks/task_e_689375c2ece4832aa577dfb74bdff642