### PR TITLE
Add adjustHealth support

### DIFF
--- a/src/scripts/boxer.js
+++ b/src/scripts/boxer.js
@@ -274,7 +274,7 @@ export class Boxer {
   }
 
   takeDamage(amount) {
-    this.health = Phaser.Math.Clamp(this.health - amount, 0, this.maxHealth);
+    this.adjustHealth(-amount);
 
     if (this.health === 0) {
       this.sprite.removeAllListeners('animationcomplete');

--- a/src/scripts/health-manager.js
+++ b/src/scripts/health-manager.js
@@ -16,9 +16,10 @@ export class HealthManager {
   damage(targetKey, amount) {
     const boxer = targetKey === 'p1' ? this.boxer1 : this.boxer2;
     boxer.takeDamage(amount);
-    eventBus.emit('health-changed', {
-      player: targetKey,
-      value: boxer.health / boxer.maxHealth,
-    });
+  }
+
+  adjustHealth(targetKey, delta) {
+    const boxer = targetKey === 'p1' ? this.boxer1 : this.boxer2;
+    boxer.adjustHealth(delta);
   }
 }


### PR DESCRIPTION
## Summary
- Add adjustHealth helper to HealthManager for modifying a boxer's health
- Route takeDamage through adjustHealth so updates emit health-changed events automatically

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6893c0423350832ab13e5bc88d7f3531