### PR TITLE
Fix boxer selection after restarting match

### DIFF
--- a/src/scripts/select-boxer-scene.js
+++ b/src/scripts/select-boxer-scene.js
@@ -12,12 +12,16 @@ export class SelectBoxerScene extends Phaser.Scene {
   create() {
     const width = this.sys.game.config.width;
     this.instruction = this.add
-      .text(width / 2, 20, 'Choose your boxer', {
+      .text(width / 2, 20, '', {
         font: '24px Arial',
         color: '#ffffff',
       })
       .setOrigin(0.5, 0);
-    this.showBoxerOptions();
+    // When returning to this scene (e.g. after a match) the previous
+    // selection state may still linger because the scene instance is
+    // reused.  Reset everything so that the boxer options can be
+    // selected again.
+    this.resetSelection();
   }
 
   showBoxerOptions() {
@@ -49,7 +53,11 @@ export class SelectBoxerScene extends Phaser.Scene {
   }
 
   clearOptions() {
-    this.options.forEach((o) => o.destroy());
+    this.options.forEach((o) => {
+      if (o && !o.destroyed) {
+        o.destroy();
+      }
+    });
     this.options = [];
   }
 
@@ -130,7 +138,6 @@ Strategy: ${this.selectedStrategy}`;
   }
 
   resetSelection() {
-    this.clearOptions();
     this.choice = [];
     this.step = 1;
     this.selectedStrategy = null;


### PR DESCRIPTION
## Summary
- Reset SelectBoxer scene state when returning so options are clickable again
- Guard option cleanup to avoid destroying already-destroyed objects

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68945609a4dc832ab47a80954c475b2c