### PR TITLE
Add scoring and round limits

### DIFF
--- a/src/scripts/overlay.js
+++ b/src/scripts/overlay.js
@@ -47,6 +47,17 @@ export class OverlayUI extends Phaser.Scene {
       },
     };
 
+    this.hitText = {
+      p1: this.add.text(20, 80, 'Hits: 0', {
+        font: '16px Arial',
+        color: '#ffffff',
+      }),
+      p2: this.add.text(width - 170, 80, 'Hits: 0', {
+        font: '16px Arial',
+        color: '#ffffff',
+      }),
+    };
+
     // initialize full bars
     this.setBarValue(this.bars.p1.stamina, 1);
     this.setBarValue(this.bars.p1.power, 1);
@@ -67,7 +78,11 @@ export class OverlayUI extends Phaser.Scene {
     eventBus.on('power-changed', ({ player, value }) => {
       this.setBarValue(this.bars[player].power, value);
     });
-    eventBus.on('match-winner', (name) => this.announceWinner(name));
+    eventBus.on('match-winner', (data) => this.announceWinner(data));
+    eventBus.on('hit-update', ({ p1, p2 }) => {
+      this.hitText.p1.setText(`Hits: ${p1}`);
+      this.hitText.p2.setText(`Hits: ${p2}`);
+    });
 
     this.events.once(Phaser.Scenes.Events.SHUTDOWN, () => {
       eventBus.off('timer-tick');
@@ -77,6 +92,7 @@ export class OverlayUI extends Phaser.Scene {
       eventBus.off('stamina-changed');
       eventBus.off('power-changed');
       eventBus.off('match-winner');
+      eventBus.off('hit-update');
     });
   }
 
@@ -115,9 +131,13 @@ export class OverlayUI extends Phaser.Scene {
     this.updateTimerText(0);
   }
 
-  announceWinner(name) {
+  announceWinner({ name, method, round }) {
     if (this.roundText) {
-      this.roundText.setText(`${name} wins by KO!`);
+      if (method === 'KO') {
+        this.roundText.setText(`${name} wins by KO in round ${round}!`);
+      } else {
+        this.roundText.setText(`${name} wins on points!`);
+      }
     }
     if (!this.newMatchText) {
       const width = this.sys.game.config.width;

--- a/src/scripts/select-boxer-scene.js
+++ b/src/scripts/select-boxer-scene.js
@@ -7,6 +7,7 @@ export class SelectBoxerScene extends Phaser.Scene {
     this.choice = [];
     this.options = [];
     this.selectedStrategy = null;
+    this.selectedRounds = null;
   }
 
   create() {
@@ -75,12 +76,35 @@ export class SelectBoxerScene extends Phaser.Scene {
 
   selectStrategy(level) {
     this.selectedStrategy = level;
-    // Defer showing the summary until the pointer is released.
+    // Defer showing the next options until the pointer is released.
     // Destroying interactive objects during their pointerdown handler
     // can leave the input system in an inconsistent state, which makes
     // subsequent buttons (like OK/Cancel) unresponsive. Waiting for the
     // pointerup event ensures the previous interaction completes before
     // clearing the options and adding new interactive elements.
+    this.input.once('pointerup', () => {
+      this.step = 4;
+      this.instruction.setText('Choose number of rounds (1-13)');
+      this.showRoundOptions();
+    });
+  }
+
+  showRoundOptions() {
+    this.clearOptions();
+    for (let i = 1; i <= 13; i++) {
+      const y = 60 + i * 25;
+      const txt = this.add.text(50, y, `${i}`, {
+        font: '20px Arial',
+        color: '#ffffff',
+      });
+      txt.setInteractive({ useHandCursor: true });
+      txt.on('pointerdown', () => this.selectRounds(i));
+      this.options.push(txt);
+    }
+  }
+
+  selectRounds(num) {
+    this.selectedRounds = num;
     this.input.once('pointerup', () => this.showSummary());
   }
 
@@ -92,7 +116,8 @@ export class SelectBoxerScene extends Phaser.Scene {
 
     const summaryText = `You: ${player.name}
 Opponent: ${opponent.name}
-Strategy: ${this.selectedStrategy}`;
+Strategy: ${this.selectedStrategy}
+Rounds: ${this.selectedRounds}`;
     const summary = this.add
       .text(width / 2, 80, summaryText, {
         font: '20px Arial',
@@ -141,6 +166,7 @@ Strategy: ${this.selectedStrategy}`;
     this.choice = [];
     this.step = 1;
     this.selectedStrategy = null;
+    this.selectedRounds = null;
     this.instruction.setText('Choose your boxer');
     this.showBoxerOptions();
   }
@@ -148,11 +174,13 @@ Strategy: ${this.selectedStrategy}`;
   startMatch() {
     const [boxer1, boxer2] = this.choice;
     const aiLevel = this.selectedStrategy ?? 1;
+    const rounds = this.selectedRounds ?? 1;
     this.scene.launch('OverlayUI');
     this.scene.start('Match', {
       boxer1,
       boxer2,
       aiLevel,
+      rounds,
     });
   }
 }


### PR DESCRIPTION
## Summary
- allow selecting number of rounds before match start
- track and display unblocked hits for each boxer
- decide winner by points after final round and show KO round info

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68946c237f30832abb78c1eb4e58541d