### PR TITLE
Add Dockerfile for Nginx-based game container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,5 @@
+FROM nginx:alpine
+COPY src/index.html /usr/share/nginx/html/index.html
+COPY src/assets /usr/share/nginx/html/assets
+COPY src/scripts /usr/share/nginx/html/scripts
+EXPOSE 80


### PR DESCRIPTION
## Summary
- add Dockerfile that uses `nginx:alpine` to serve index.html and related assets

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689482efbe88832a931caa4af6dbb4e0