### PR TITLE
feat: display app name and version above timer

### DIFF
--- a/src/scripts/config.js
+++ b/src/scripts/config.js
@@ -1,0 +1,4 @@
+export const appConfig = {
+  name: 'The boxer',
+  version: '0.0.001'
+};

--- a/src/scripts/overlay.js
+++ b/src/scripts/overlay.js
@@ -1,4 +1,5 @@
 import { eventBus } from './event-bus.js';
+import { appConfig } from './config.js';
 
 export class OverlayUI extends Phaser.Scene {
   constructor() {
@@ -9,14 +10,26 @@ export class OverlayUI extends Phaser.Scene {
 
   create() {
     const width = this.sys.game.config.width;
-    // create timer text centered at top
-    this.timerText = this.add.text(width / 2, 20, '0:00', {
+    // show application name and version
+    this.appInfoText = this.add.text(
+      width / 2,
+      10,
+      `${appConfig.name} v${appConfig.version}`,
+      {
+        font: '20px Arial',
+        color: '#ffffff',
+      }
+    );
+    this.appInfoText.setOrigin(0.5, 0);
+
+    // create timer text centered slightly lower
+    this.timerText = this.add.text(width / 2, 40, '0:00', {
       font: '24px Arial',
       color: '#ffffff',
     });
     this.timerText.setOrigin(0.5, 0);
 
-    this.roundText = this.add.text(width / 2, 50, '', {
+    this.roundText = this.add.text(width / 2, 70, '', {
       font: '24px Arial',
       color: '#ffffff',
     });


### PR DESCRIPTION
## Summary
- show app name and version from config at top of overlay
- move timer and round labels down

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6894e5d972b0832aae8192bed16996fe