### PR TITLE
Adjust AI strategy when trailing on points

### DIFF
--- a/src/scripts/match-scene.js
+++ b/src/scripts/match-scene.js
@@ -221,6 +221,19 @@ export class MatchScene extends Phaser.Scene {
     if (round >= this.maxRounds) {
       this.determineWinnerByPoints();
     } else {
+      const shift = round === this.maxRounds - 1 ? 3 : 1;
+      if (
+        this.hits.p1 < this.hits.p2 &&
+        typeof this.player1.controller.shiftLevel === 'function'
+      ) {
+        this.player1.controller.shiftLevel(shift);
+      }
+      if (
+        this.hits.p2 < this.hits.p1 &&
+        typeof this.player2.controller.shiftLevel === 'function'
+      ) {
+        this.player2.controller.shiftLevel(shift);
+      }
       this.resetBoxers();
       this.recoverBoxer(this.player1);
       this.recoverBoxer(this.player2);


### PR DESCRIPTION
## Summary
- Increase AI strategy level by one when trailing on points at round breaks
- Step up three levels if still behind entering the final round

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689519f09494832a820c81af717a14b1