### PR TITLE
feat: differentiate boxer strategies

### DIFF
--- a/src/scripts/ai-strategies.js
+++ b/src/scripts/ai-strategies.js
@@ -59,7 +59,12 @@ function generateStrategy(level) {
   return actions;
 }
 
-export const STRATEGIES = Array.from({ length: 10 }, (_, i) => ({
+// Separate strategy sets for each boxer so identical levels don't share actions
+export const STRATEGIES_P1 = Array.from({ length: 10 }, (_, i) => ({
+  actions: generateStrategy(i + 1),
+}));
+
+export const STRATEGIES_P2 = Array.from({ length: 10 }, (_, i) => ({
   actions: generateStrategy(i + 1),
 }));
 

--- a/src/scripts/match-scene.js
+++ b/src/scripts/match-scene.js
@@ -30,7 +30,7 @@ export class MatchScene extends Phaser.Scene {
 
     // Player 1 may be human or AI controlled; player 2 always AI
     const controller1 = data?.aiLevel1
-      ? new StrategyAIController(data.aiLevel1)
+      ? new StrategyAIController(data.aiLevel1, 1)
       : new KeyboardController(this, {
           block: 'S',
           jabRight: 'E',
@@ -45,7 +45,7 @@ export class MatchScene extends Phaser.Scene {
           left: 'A',
           right: 'D',
         });
-    const controller2 = new StrategyAIController(data?.aiLevel2 || 1);
+    const controller2 = new StrategyAIController(data?.aiLevel2 || 1, 2);
 
     const centerX = width / 2;
     const centerY = height / 2;

--- a/src/scripts/rule-manager.js
+++ b/src/scripts/rule-manager.js
@@ -1,4 +1,4 @@
-import { STRATEGIES } from './ai-strategies.js';
+import { STRATEGIES_P1, STRATEGIES_P2 } from './ai-strategies.js';
 
 export class RuleManager {
   constructor(boxer1, boxer2) {
@@ -59,9 +59,11 @@ export class RuleManager {
 
       const getActions = (boxer) => {
         const ctrl = boxer.controller;
-        return typeof ctrl.getLevel === 'function'
-          ? STRATEGIES[ctrl.getLevel() - 1].actions
-          : null;
+        if (typeof ctrl.getLevel === 'function') {
+          const strategies = boxer === this.b1 ? STRATEGIES_P1 : STRATEGIES_P2;
+          return strategies[ctrl.getLevel() - 1].actions;
+        }
+        return null;
       };
 
       const a1 = getActions(this.b1);

--- a/src/scripts/strategy-ai-controller.js
+++ b/src/scripts/strategy-ai-controller.js
@@ -1,4 +1,4 @@
-import { STRATEGIES, createBaseActions } from './ai-strategies.js';
+import { STRATEGIES_P1, STRATEGIES_P2, createBaseActions } from './ai-strategies.js';
 
 function convertAction(action, boxer, opponent) {
   if (action.none) return createBaseActions();
@@ -19,11 +19,12 @@ function convertAction(action, boxer, opponent) {
 }
 
 export class StrategyAIController {
-  constructor(level = 1) {
+  constructor(level = 1, boxerId = 1) {
     this.level = Phaser.Math.Clamp(level, 1, 10);
     this.index = 0;
     this.lastDecision = -1;
     this.cached = createBaseActions();
+    this.boxerId = boxerId === 2 ? 2 : 1;
   }
 
   getLevel() {
@@ -39,7 +40,8 @@ export class StrategyAIController {
   }
 
   getActions(boxer, opponent, currentSecond) {
-    const strategy = STRATEGIES[this.level - 1];
+    const strategies = this.boxerId === 1 ? STRATEGIES_P1 : STRATEGIES_P2;
+    const strategy = strategies[this.level - 1];
     if (currentSecond !== this.lastDecision) {
       const action = strategy.actions[this.index % strategy.actions.length];
       this.cached = convertAction(action, boxer, opponent);


### PR DESCRIPTION
## Summary
- generate separate strategy sets for player and opponent
- apply boxer-specific strategies in AI controller and rule manager
- pass boxer ID from match scene when creating AI controllers

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689539de4dc4832aa80e3c870b8548f3