### PR TITLE
Add boxer default strategies and test mode toggle

### DIFF
--- a/src/scripts/boxer-data.js
+++ b/src/scripts/boxer-data.js
@@ -1,3 +1,9 @@
+function defaultStrategyForRanking(ranking) {
+  const max = Math.min(7, 11 - ranking);
+  const min = Math.max(1, max - 2);
+  return Math.floor(Math.random() * (max - min + 1)) + min;
+}
+
 export const BOXERS = [
   {
     name: 'Glass Joe',
@@ -12,7 +18,8 @@ export const BOXERS = [
     losses: 10,
     draws: 1,
     winsByKO: 0,
-    age: 29
+    age: 29,
+    defaultStrategy: defaultStrategyForRanking(10),
   },
   {
     name: 'Von Kaiser',
@@ -27,7 +34,8 @@ export const BOXERS = [
     losses: 17,
     draws: 5,
     winsByKO: 0,
-    age: 36
+    age: 36,
+    defaultStrategy: defaultStrategyForRanking(9),
   },
   {
     name: 'Piston Honda',
@@ -42,7 +50,8 @@ export const BOXERS = [
     losses: 5,
     draws: 1,
     winsByKO: 2,
-    age: 23
+    age: 23,
+    defaultStrategy: defaultStrategyForRanking(8),
   },
   {
     name: 'Don Flamenco',
@@ -57,7 +66,8 @@ export const BOXERS = [
     losses: 10,
     draws: 0,
     winsByKO: 2,
-    age: 27
+    age: 27,
+    defaultStrategy: defaultStrategyForRanking(7),
   },
   {
     name: 'King Hippo',
@@ -72,7 +82,8 @@ export const BOXERS = [
     losses: 2,
     draws: 0,
     winsByKO: 3,
-    age: 21
+    age: 21,
+    defaultStrategy: defaultStrategyForRanking(6),
   },
   {
     name: 'Great Tiger',
@@ -87,7 +98,8 @@ export const BOXERS = [
     losses: 12,
     draws: 3,
     winsByKO: 8,
-    age: 32
+    age: 32,
+    defaultStrategy: defaultStrategyForRanking(5),
   },
   {
     name: 'Bald Bull',
@@ -102,7 +114,8 @@ export const BOXERS = [
     losses: 10,
     draws: 0,
     winsByKO: 12,
-    age: 27
+    age: 27,
+    defaultStrategy: defaultStrategyForRanking(4),
   },
   {
     name: 'Soda Popinski',
@@ -117,7 +130,8 @@ export const BOXERS = [
     losses: 8,
     draws: 2,
     winsByKO: 20,
-    age: 37
+    age: 37,
+    defaultStrategy: defaultStrategyForRanking(3),
   },
   {
     name: 'Mr. Sandman',
@@ -132,7 +146,8 @@ export const BOXERS = [
     losses: 5,
     draws: 0,
     winsByKO: 29,
-    age: 30
+    age: 30,
+    defaultStrategy: defaultStrategyForRanking(2),
   },
   {
     name: 'Mike Tyson',
@@ -147,6 +162,7 @@ export const BOXERS = [
     losses: 0,
     draws: 0,
     winsByKO: 33,
-    age: 23
+    age: 23,
+    defaultStrategy: defaultStrategyForRanking(1),
   },
 ];

--- a/src/scripts/boxer.js
+++ b/src/scripts/boxer.js
@@ -43,6 +43,7 @@ export class Boxer {
     this.maxStamina = this.stamina;
     this.maxHealth = stats.health || 1;
     this.health = this.maxHealth;
+    this.defaultStrategy = stats.defaultStrategy || 1;
     // slightly smaller boxer sprites
     this.sprite.setScale(350 / this.sprite.height);
     // boxer1 faces right, boxer2 faces left

--- a/src/scripts/config.js
+++ b/src/scripts/config.js
@@ -2,3 +2,13 @@ export const appConfig = {
   name: 'The boxer',
   version: '0.0.001'
 };
+
+let testMode = true;
+
+export function setTestMode(value) {
+  testMode = value;
+}
+
+export function getTestMode() {
+  return testMode;
+}

--- a/src/scripts/match-scene.js
+++ b/src/scripts/match-scene.js
@@ -31,7 +31,12 @@ export class MatchScene extends Phaser.Scene {
 
     // Player 1 may be human or AI controlled; player 2 always AI
     const controller1 = data?.aiLevel1
-      ? new StrategyAIController(data.aiLevel1, 1)
+      ? new StrategyAIController(
+          data.aiLevel1 === 'default'
+            ? data.boxer1?.defaultStrategy || 1
+            : data.aiLevel1,
+          1
+        )
       : new KeyboardController(this, {
           block: 'S',
           jabRight: 'E',
@@ -46,7 +51,12 @@ export class MatchScene extends Phaser.Scene {
           left: 'A',
           right: 'D',
         });
-    const controller2 = new StrategyAIController(data?.aiLevel2 || 1, 2);
+    const controller2 = new StrategyAIController(
+      data?.aiLevel2 === 'default'
+        ? data.boxer2?.defaultStrategy || 1
+        : data?.aiLevel2 || 1,
+      2
+    );
 
     const centerX = width / 2;
     const centerY = height / 2;

--- a/src/scripts/ranking-scene.js
+++ b/src/scripts/ranking-scene.js
@@ -1,4 +1,5 @@
 import { getRankings } from './boxer-stats.js';
+import { getTestMode, setTestMode } from './config.js';
 
 export class RankingScene extends Phaser.Scene {
   constructor() {
@@ -38,8 +39,8 @@ export class RankingScene extends Phaser.Scene {
       });
     });
 
-    this.add
-      .text(width / 2, height - 60, 'New game', {
+    const startBtn = this.add
+      .text(width / 2, height - 60, 'Start new game', {
         font: '24px Arial',
         color: '#00ff00',
       })
@@ -48,6 +49,31 @@ export class RankingScene extends Phaser.Scene {
       .on('pointerup', () => {
         this.scene.start('SelectBoxer');
       });
+
+    const cbX = width / 2 + 180;
+    const cbY = height - 65;
+    const testBox = this.add
+      .rectangle(cbX, cbY, 20, 20, 0xffffff)
+      .setOrigin(0, 0)
+      .setInteractive({ useHandCursor: true });
+    const testCheck = this.add
+      .text(cbX + 10, cbY, 'X', {
+        font: '20px Arial',
+        color: '#000000',
+      })
+      .setOrigin(0.5, 0)
+      .setVisible(getTestMode());
+    this.add
+      .text(cbX + 30, cbY - 5, 'Test mode', {
+        font: '20px Arial',
+        color: '#ffffff',
+      })
+      .setOrigin(0, 0);
+    testBox.on('pointerdown', () => {
+      const newVal = !getTestMode();
+      setTestMode(newVal);
+      testCheck.setVisible(newVal);
+    });
   }
 }
 

--- a/src/scripts/select-boxer-scene.js
+++ b/src/scripts/select-boxer-scene.js
@@ -1,4 +1,5 @@
 import { getRankings } from './boxer-stats.js';
+import { getTestMode } from './config.js';
 
 export class SelectBoxerScene extends Phaser.Scene {
   constructor() {
@@ -83,8 +84,16 @@ export class SelectBoxerScene extends Phaser.Scene {
 
   showStrategyOptions() {
     this.clearOptions();
+    let y = 60;
+    const defTxt = this.add.text(50, y, `Default`, {
+      font: '20px Arial',
+      color: '#ffffff',
+    });
+    defTxt.setInteractive({ useHandCursor: true });
+    defTxt.on('pointerdown', () => this.selectStrategy('default'));
+    this.options.push(defTxt);
     for (let i = 1; i <= 10; i++) {
-      const y = 60 + i * 30;
+      y += 30;
       const txt = this.add.text(50, y, `Strategy ${i}`, {
         font: '20px Arial',
         color: '#ffffff',
@@ -112,14 +121,27 @@ export class SelectBoxerScene extends Phaser.Scene {
         this.step = 3;
         this.instruction.setText('Choose your opponent');
       } else {
-        this.step = 2;
-        this.instruction.setText('Choose Player 1 strategy');
-        this.showStrategyOptions();
+        if (getTestMode()) {
+          this.step = 2;
+          this.instruction.setText('Choose Player 1 strategy');
+          this.showStrategyOptions();
+        } else {
+          this.selectedStrategy1 = 'default';
+          this.step = 3;
+          this.instruction.setText('Choose your opponent');
+        }
       }
     } else if (this.step === 3) {
-      this.step = 4;
-      this.instruction.setText("Choose the opponent's strategy");
-      this.showStrategyOptions();
+      if (getTestMode()) {
+        this.step = 4;
+        this.instruction.setText("Choose the opponent's strategy");
+        this.showStrategyOptions();
+      } else {
+        this.selectedStrategy2 = 'default';
+        this.step = 5;
+        this.instruction.setText('Choose number of rounds (1-13)');
+        this.showRoundOptions();
+      }
     }
   }
 
@@ -170,9 +192,17 @@ export class SelectBoxerScene extends Phaser.Scene {
       `Player 1: ${player.name}`,
       this.isBoxer1Human
         ? 'Human controlled'
-        : `Strategy: ${this.selectedStrategy1}`,
+        : `Strategy: ${
+            this.selectedStrategy1 === 'default'
+              ? 'Default'
+              : this.selectedStrategy1
+          }`,
       `Player 2: ${opponent.name}`,
-      `Strategy: ${this.selectedStrategy2}`,
+      `Strategy: ${
+        this.selectedStrategy2 === 'default'
+          ? 'Default'
+          : this.selectedStrategy2
+      }`,
       `Rounds: ${this.selectedRounds}`,
     ];
     const summaryText = summaryLines.join('\n');
@@ -236,8 +266,10 @@ export class SelectBoxerScene extends Phaser.Scene {
   startMatch() {
     const [boxer1, boxer2] = this.choice;
     const rounds = this.selectedRounds ?? 1;
-    const aiLevel1 = this.isBoxer1Human ? null : this.selectedStrategy1 ?? 1;
-    const aiLevel2 = this.selectedStrategy2 ?? 1;
+    const aiLevel1 = this.isBoxer1Human
+      ? null
+      : this.selectedStrategy1 ?? 'default';
+    const aiLevel2 = this.selectedStrategy2 ?? 'default';
     this.scene.launch('OverlayUI');
     this.scene.start('Match', {
       boxer1,


### PR DESCRIPTION
## Summary
- Introduce global test mode flag and UI toggle on ranking screen
- Add default strategy value for each boxer and allow using it in match setup
- Provide "Default" strategy option and skip strategy selection when not in test mode

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_6895c3437b54832a9a7f62d01fe23011