### PR TITLE
Force losing boxer to max strategy in final minute

### DIFF
--- a/src/scripts/match-scene.js
+++ b/src/scripts/match-scene.js
@@ -185,6 +185,32 @@ export class MatchScene extends Phaser.Scene {
     const currentSecond = this.roundLength - this.roundTimer.remaining;
     if (currentSecond !== this.lastSecond && currentSecond < this.roundLength) {
       this.ruleManager.evaluate(currentSecond);
+      // If one minute remains in the final round, force the boxer who is
+      // trailing on points to switch to the most aggressive strategy. The
+      // existing rule limiting strategy changes still applies.
+      if (
+        this.roundTimer.round === this.maxRounds &&
+        this.roundTimer.remaining === 60
+      ) {
+        let behind = null;
+        if (this.hits.p1 === this.hits.p2) {
+          if (this.player1.health < this.player2.health) behind = this.player1;
+          else if (this.player2.health < this.player1.health)
+            behind = this.player2;
+        } else {
+          behind = this.hits.p1 < this.hits.p2 ? this.player1 : this.player2;
+        }
+        if (behind) {
+          const key = behind === this.player1 ? 'p1' : 'p2';
+          const ctrl = behind.controller;
+          if (
+            typeof ctrl.setLevel === 'function' &&
+            this.ruleManager.canShift(key, currentSecond)
+          ) {
+            ctrl.setLevel(10);
+          }
+        }
+      }
       this.lastSecond = currentSecond;
     }
 


### PR DESCRIPTION
## Summary
- Ensure that at one minute remaining in the final round, the boxer trailing on points shifts to strategy level 10 for a last-ditch effort, provided strategy changes are allowed.

## Testing
- `npm test` (fails: ENOENT, package.json not found)


------
https://chatgpt.com/codex/tasks/task_e_6895c81152c8832a85cfe67955c143f3