### PR TITLE
Adjust boxer start positions and streamline overlay

### DIFF
--- a/src/scripts/match-scene.js
+++ b/src/scripts/match-scene.js
@@ -61,32 +61,36 @@ export class MatchScene extends Phaser.Scene {
     const centerX = width / 2;
     const centerY = height / 2;
     const ringWidth = 880; // slightly larger ring
-    const margin = 50;
+    const ringLeft = centerX - ringWidth / 2;
+    const ringRight = centerX + ringWidth / 2;
     const startY = centerY - 100; // position boxers a bit higher
-    this.player1Start = {
-      x: centerX - ringWidth / 2 + margin,
-      y: startY,
-    };
-    this.player2Start = {
-      x: centerX + ringWidth / 2 - margin,
-      y: startY,
-    };
+
     this.player1 = new Boxer(
       this,
-      this.player1Start.x,
-      this.player1Start.y,
+      centerX,
+      startY,
       BOXER_PREFIXES.P1,
       controller1,
       data?.boxer1
     );
     this.player2 = new Boxer(
       this,
-      this.player2Start.x,
-      this.player2Start.y,
+      centerX,
+      startY,
       BOXER_PREFIXES.P2,
       controller2,
       data?.boxer2
     );
+
+    const halfWidth = this.player1.sprite.displayWidth / 2;
+    this.player1Start = {
+      x: ringLeft + halfWidth,
+      y: startY,
+    };
+    this.player2Start = {
+      x: ringRight - halfWidth,
+      y: startY,
+    };
 
     this.resetBoxers();
 
@@ -224,18 +228,8 @@ export class MatchScene extends Phaser.Scene {
         : 'Human controlled boxer';
     const rule1 = `Rule: ${this.ruleManager.boxerRules.p1 || 'none'}`;
     const rule2 = `Rule: ${this.ruleManager.boxerRules.p2 || 'none'}`;
-    this.debugText.p1.setText(
-      `Stamina: ${this.player1.stamina.toFixed(2)}\n` +
-        `Power: ${this.player1.power.toFixed(2)}\n` +
-        `Health: ${this.player1.health.toFixed(2)}\n` +
-        `${strat1}\n${rule1}`
-    );
-    this.debugText.p2.setText(
-      `Stamina: ${this.player2.stamina.toFixed(2)}\n` +
-        `Power: ${this.player2.power.toFixed(2)}\n` +
-        `Health: ${this.player2.health.toFixed(2)}\n` +
-        `${strat2}\n${rule2}`
-    );
+    this.debugText.p1.setText(`${strat1}\n${rule1}`);
+    this.debugText.p2.setText(`${strat2}\n${rule2}`);
 
     if (this.paused) return;
 
@@ -367,10 +361,6 @@ export class MatchScene extends Phaser.Scene {
       `Age: ${b1.age ?? ''}`,
       `Record: ${b1.wins || 0}-${b1.losses || 0}-${b1.draws || 0}`,
       `KO: ${b1.winsByKO || 0}`,
-      `Stamina: ${b1.stamina || 0}`,
-      `Power: ${b1.power || 0}`,
-      `Health: ${b1.health || 0}`,
-      `Speed: ${b1.speed || 0}`,
     ];
     const lines2 = [
       `Name: ${b2.name || ''}`,
@@ -379,10 +369,6 @@ export class MatchScene extends Phaser.Scene {
       `Age: ${b2.age ?? ''}`,
       `Record: ${b2.wins || 0}-${b2.losses || 0}-${b2.draws || 0}`,
       `KO: ${b2.winsByKO || 0}`,
-      `Stamina: ${b2.stamina || 0}`,
-      `Power: ${b2.power || 0}`,
-      `Health: ${b2.health || 0}`,
-      `Speed: ${b2.speed || 0}`,
     ];
 
     this.introPanels = {

--- a/src/scripts/overlay.js
+++ b/src/scripts/overlay.js
@@ -11,10 +11,16 @@ export class OverlayUI extends Phaser.Scene {
 
   create() {
     const width = this.sys.game.config.width;
+    const infoY = 40;
+    const infoHeight = 120;
+    this.add
+      .rectangle(width / 2, infoY, width, infoHeight, 0x808080, 0.5)
+      .setOrigin(0.5, 0);
+
     // show application name and version
     this.appInfoText = this.add.text(
       width / 2,
-      10,
+      infoY + 10,
       `${appConfig.name} v${appConfig.version}`,
       {
         font: '20px Arial',
@@ -24,74 +30,43 @@ export class OverlayUI extends Phaser.Scene {
     this.appInfoText.setOrigin(0.5, 0);
 
     // create timer text centered slightly lower
-    this.timerText = this.add.text(width / 2, 40, '0:00', {
+    this.timerText = this.add.text(width / 2, infoY + 40, '0:00', {
       font: '24px Arial',
       color: '#ffffff',
     });
     this.timerText.setOrigin(0.5, 0);
 
-    this.roundText = this.add.text(width / 2, 70, '', {
+    this.roundText = this.add.text(width / 2, infoY + 70, '', {
       font: '24px Arial',
       color: '#ffffff',
     });
     this.roundText.setOrigin(0.5, 0);
 
     this.nameText = {
-      p1: this.add.text(20, 2, this.pendingNames[0], {
+      p1: this.add.text(20, infoY + 2, this.pendingNames[0], {
         font: '20px Arial',
         color: '#ffffff',
       }),
-      p2: this.add.text(width - 170, 2, this.pendingNames[1], {
+      p2: this.add.text(width - 170, infoY + 2, this.pendingNames[1], {
         font: '20px Arial',
         color: '#ffffff',
       }),
-    };
-
-    // create bars for player1 and player2
-    this.bars = {
-      p1: {
-        stamina: this.createBar(20, 20, 150, 15, 0x00aa00),
-        power: this.createBar(20, 40, 150, 15, 0x0000aa),
-        health: this.createBar(20, 60, 150, 15, 0xaa0000),
-      },
-      p2: {
-        stamina: this.createBar(width - 170, 20, 150, 15, 0x00aa00),
-        power: this.createBar(width - 170, 40, 150, 15, 0x0000aa),
-        health: this.createBar(width - 170, 60, 150, 15, 0xaa0000),
-      },
     };
 
     this.hitText = {
-      p1: this.add.text(20, 80, 'Hits: 0', {
+      p1: this.add.text(20, infoY + 90, 'Hits: 0', {
         font: '16px Arial',
         color: '#ffffff',
       }),
-      p2: this.add.text(width - 170, 80, 'Hits: 0', {
+      p2: this.add.text(width - 170, infoY + 90, 'Hits: 0', {
         font: '16px Arial',
         color: '#ffffff',
       }),
     };
-
-    // initialize full bars
-    this.setBarValue(this.bars.p1.stamina, 1);
-    this.setBarValue(this.bars.p1.power, 1);
-    this.setBarValue(this.bars.p1.health, 1);
-    this.setBarValue(this.bars.p2.stamina, 1);
-    this.setBarValue(this.bars.p2.power, 1);
-    this.setBarValue(this.bars.p2.health, 1);
 
     eventBus.on('timer-tick', (seconds) => this.updateTimerText(seconds));
     eventBus.on('round-started', (round) => this.showRound(round));
     eventBus.on('set-names', ({ p1, p2 }) => this.setNames(p1, p2));
-    eventBus.on('health-changed', ({ player, value }) => {
-      this.setBarValue(this.bars[player].health, value);
-    });
-    eventBus.on('stamina-changed', ({ player, value }) => {
-      this.setBarValue(this.bars[player].stamina, value);
-    });
-    eventBus.on('power-changed', ({ player, value }) => {
-      this.setBarValue(this.bars[player].power, value);
-    });
     eventBus.on('match-winner', (data) => this.announceWinner(data));
     eventBus.on('hit-update', ({ p1, p2 }) => {
       this.hitText.p1.setText(`Hits: ${p1}`);
@@ -102,23 +77,9 @@ export class OverlayUI extends Phaser.Scene {
       eventBus.off('timer-tick');
       eventBus.off('round-started');
       eventBus.off('set-names');
-      eventBus.off('health-changed');
-      eventBus.off('stamina-changed');
-      eventBus.off('power-changed');
       eventBus.off('match-winner');
       eventBus.off('hit-update');
     });
-  }
-
-  createBar(x, y, width, height, color) {
-    const bg = this.add.rectangle(x, y, width, height, 0x444444).setOrigin(0, 0);
-    const fill = this.add.rectangle(x + 1, y + 1, width - 2, height - 2, color).setOrigin(0, 0);
-    return { bg, fill, width: width - 2 };
-  }
-
-  setBarValue(bar, value) {
-    const w = Phaser.Math.Clamp(value, 0, 1) * bar.width;
-    bar.fill.width = w;
   }
 
   updateTimerText(seconds) {


### PR DESCRIPTION
## Summary
- Start boxers just inside ring edges based on sprite width
- Remove stamina, health, power, and speed displays and add gray transparent info box

## Testing
- `node --check src/scripts/overlay.js`
- `node --check src/scripts/match-scene.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6895d228ba10832a894791b1be6c9af6