### PR TITLE
Expose boxer metadata via boxerData property

### DIFF
--- a/src/scripts/boxer.js
+++ b/src/scripts/boxer.js
@@ -36,6 +36,7 @@ export class Boxer {
     this.prefix = prefix;
     this.controller = controller;
     this.stats = stats;
+    this.boxerData = stats;
     this.speed = 100 * (stats.speed || 1);
     this.power = stats.power || 1;
     this.maxPower = this.power;


### PR DESCRIPTION
## Summary
- expose original boxer data on Boxer instances via `boxerData`

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_6895ee85d6f0832abf75da58c7a7e2da