### PR TITLE
Add audio manager and integrate boxing game sound effects

### DIFF
--- a/src/scripts/hit-manager.js
+++ b/src/scripts/hit-manager.js
@@ -1,5 +1,6 @@
 import { eventBus } from './event-bus.js';
 import { animKey } from './helpers.js';
+import { SoundManager } from './sound-manager.js';
 
 export class HitManager {
   constructor(healthManager, hitLimit, hits) {
@@ -60,7 +61,12 @@ export class HitManager {
     }
 
     this.healthManager.damage(defenderKey, damage);
-    if (!blocked) {
+    if (blocked) {
+      SoundManager.playBlock();
+    } else {
+      if (punch === 'jabLeft') SoundManager.playLeftJab();
+      else if (punch === 'jabRight') SoundManager.playRightJab();
+      else if (punch === 'uppercut') SoundManager.playUppercut();
       const attackerKey = defenderKey === 'p1' ? 'p2' : 'p1';
       this.hits[attackerKey] += 1;
       eventBus.emit('hit-update', { p1: this.hits.p1, p2: this.hits.p2 });

--- a/src/scripts/main.js
+++ b/src/scripts/main.js
@@ -2,6 +2,7 @@ import { MatchScene } from './match-scene.js';
 import { SelectBoxerScene } from './select-boxer-scene.js';
 import { OverlayUI } from './overlay.js';
 import { RankingScene } from './ranking-scene.js';
+import { SoundManager } from './sound-manager.js';
 
 class BootScene extends Phaser.Scene {
   constructor() {
@@ -11,6 +12,16 @@ class BootScene extends Phaser.Scene {
   preload() {
     console.log('BootScene: preload started');
     this.load.image('ring', 'assets/ring.png');
+    this.load.audio('loop-menu', 'assets/sounds/loop-menu.mp3');
+    this.load.audio('click-menu', 'assets/sounds/click-menu.mp3');
+    this.load.audio('intro', 'assets/sounds/intro.mp3');
+    this.load.audio('bell-signals', 'assets/sounds/bell-signals.mp3');
+    this.load.audio('fight', 'assets/sounds/fight.mp3');
+    this.load.audio('crowd-noise-01', 'assets/sounds/crowd-noise-01.mp3');
+    this.load.audio('block', 'assets/sounds/block.mp3');
+    this.load.audio('left-jab', 'assets/sounds/left-jab.mp3');
+    this.load.audio('right-jab', 'assets/sounds/right-jab.mp3');
+    this.load.audio('uppercut', 'assets/sounds/uppercut.mp3');
     // Load idle animation frames for the boxers
     for (let i = 0; i < 10; i++) {
       const frame = i.toString().padStart(3, '0');
@@ -83,6 +94,8 @@ class BootScene extends Phaser.Scene {
 
   create() {
     console.log('BootScene: preload complete, switching to Ranking');
+    SoundManager.init(this);
+    SoundManager.playMenuLoop();
     this.scene.start('Ranking');
   }
 }

--- a/src/scripts/ranking-scene.js
+++ b/src/scripts/ranking-scene.js
@@ -1,5 +1,6 @@
 import { getRankings } from './boxer-stats.js';
 import { getTestMode, setTestMode } from './config.js';
+import { SoundManager } from './sound-manager.js';
 
 export class RankingScene extends Phaser.Scene {
   constructor() {
@@ -9,6 +10,7 @@ export class RankingScene extends Phaser.Scene {
   create() {
     const width = this.sys.game.config.width;
     const height = this.sys.game.config.height;
+    SoundManager.playMenuLoop();
     this.add
       .text(width / 2, 20, 'Ranking', {
         font: '32px Arial',

--- a/src/scripts/select-boxer-scene.js
+++ b/src/scripts/select-boxer-scene.js
@@ -1,5 +1,6 @@
 import { getRankings } from './boxer-stats.js';
 import { getTestMode } from './config.js';
+import { SoundManager } from './sound-manager.js';
 
 export class SelectBoxerScene extends Phaser.Scene {
   constructor() {
@@ -128,6 +129,7 @@ export class SelectBoxerScene extends Phaser.Scene {
   }
 
   selectBoxer(boxer) {
+    SoundManager.playClick();
     this.choice.push(boxer);
     if (this.step === 1) {
       this.humanBox.disableInteractive();
@@ -160,6 +162,7 @@ export class SelectBoxerScene extends Phaser.Scene {
   }
 
   selectStrategy(level) {
+    SoundManager.playClick();
     if (this.step === 2) {
       this.selectedStrategy1 = level;
       this.input.once('pointerup', () => {
@@ -284,6 +287,8 @@ export class SelectBoxerScene extends Phaser.Scene {
       ? null
       : this.selectedStrategy1 ?? 'default';
     const aiLevel2 = this.selectedStrategy2 ?? 'default';
+    SoundManager.stopMenuLoop();
+    SoundManager.playIntro();
     this.scene.launch('OverlayUI');
     this.scene.start('Match', {
       boxer1,

--- a/src/scripts/sound-manager.js
+++ b/src/scripts/sound-manager.js
@@ -1,0 +1,91 @@
+import { eventBus } from './event-bus.js';
+
+export class SoundManager {
+  static init(scene) {
+    if (this.initialized) return;
+    this.initialized = true;
+    this.scene = scene;
+    this.sounds = {
+      menuLoop: scene.sound.add('loop-menu', { loop: true }),
+      click: scene.sound.add('click-menu'),
+      intro: scene.sound.add('intro'),
+      bell: scene.sound.add('bell-signals'),
+      fight: scene.sound.add('fight'),
+      crowd: scene.sound.add('crowd-noise-01', { loop: true }),
+      block: scene.sound.add('block'),
+      leftJab: scene.sound.add('left-jab'),
+      rightJab: scene.sound.add('right-jab'),
+      uppercut: scene.sound.add('uppercut'),
+    };
+
+    eventBus.on('round-started', () => {
+      if (this.sounds.intro && this.sounds.intro.isPlaying) {
+        this.sounds.intro.stop();
+      }
+      this.playBellStart();
+      if (this.sounds.fight) {
+        this.sounds.fight.play();
+      }
+      if (this.sounds.crowd && !this.sounds.crowd.isPlaying) {
+        this.sounds.crowd.play();
+      }
+    });
+
+    eventBus.on('round-ended', () => {
+      this.playBellEnd();
+      if (this.sounds.crowd && this.sounds.crowd.isPlaying) {
+        this.sounds.crowd.stop();
+      }
+    });
+
+    eventBus.on('match-winner', () => {
+      if (this.sounds.crowd && this.sounds.crowd.isPlaying) {
+        this.sounds.crowd.stop();
+      }
+    });
+  }
+
+  static playMenuLoop() {
+    if (this.sounds?.menuLoop && !this.sounds.menuLoop.isPlaying) {
+      this.sounds.menuLoop.play();
+    }
+  }
+
+  static stopMenuLoop() {
+    if (this.sounds?.menuLoop && this.sounds.menuLoop.isPlaying) {
+      this.sounds.menuLoop.stop();
+    }
+  }
+
+  static playClick() {
+    this.sounds?.click?.play();
+  }
+
+  static playIntro() {
+    this.sounds?.intro?.play();
+  }
+
+  static playBellStart() {
+    this.sounds?.bell?.play({ seek: 0, duration: 3 });
+  }
+
+  static playBellEnd() {
+    this.sounds?.bell?.play({ seek: 17, duration: 3 });
+  }
+
+  static playBlock() {
+    this.sounds?.block?.play();
+  }
+
+  static playLeftJab() {
+    this.sounds?.leftJab?.play();
+  }
+
+  static playRightJab() {
+    this.sounds?.rightJab?.play();
+  }
+
+  static playUppercut() {
+    this.sounds?.uppercut?.play();
+  }
+}


### PR DESCRIPTION
## Summary
- Introduce reusable `SoundManager` to centralize game audio
- Preload and initialize sounds for menus, rounds, and actions
- Play menu clicks, intro music, bells, crowd noise, and punch/block effects across scenes

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68963045a9a4832ab633438e9b8f3211