### PR TITLE
Move boxers to corners before starting next round

### DIFF
--- a/src/scripts/match-scene.js
+++ b/src/scripts/match-scene.js
@@ -273,6 +273,7 @@ export class MatchScene extends Phaser.Scene {
     if (this.matchOver) return;
     this.ruleManager.resetStrategyChanges();
     this.paused = true;
+    this.resetBoxers();
     if (round >= this.maxRounds) {
       this.determineWinnerByPoints();
     } else {
@@ -295,7 +296,6 @@ export class MatchScene extends Phaser.Scene {
 
   startNextRound() {
     if (this.matchOver || !this.pendingRound) return;
-    this.resetBoxers();
     this.recoverBoxer(this.player1);
     this.recoverBoxer(this.player2);
     this.roundTimer.start(this.roundLength, this.pendingRound);


### PR DESCRIPTION
## Summary
- reset fighters to their starting positions immediately when a round ends
- avoid redundant boxer reset when starting the next round

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689660786718832aa06196d362725536