### PR TITLE
Ensure overlay buttons stay on top

### DIFF
--- a/src/scripts/match-scene.js
+++ b/src/scripts/match-scene.js
@@ -162,6 +162,11 @@ export class MatchScene extends Phaser.Scene {
       }
     });
 
+    // Ensure the overlay UI is rendered above the match so that any
+    // interactive elements like the post-match buttons are not obscured
+    // by the boxers.
+    this.scene.bringToTop('OverlayUI');
+
     console.log('MatchScene: create complete');
   }
 

--- a/src/scripts/overlay.js
+++ b/src/scripts/overlay.js
@@ -174,6 +174,9 @@ export class OverlayUI extends Phaser.Scene {
         this.roundText.setText(`${name} wins on points!`);
       }
     }
+    // Ensure this overlay scene is rendered above the match scene so
+    // that the post-match buttons are never hidden behind the boxers.
+    this.scene.bringToTop();
     const width = this.sys.game.config.width;
     const height = this.sys.game.config.height;
     if (!this.newMatchText) {
@@ -183,7 +186,8 @@ export class OverlayUI extends Phaser.Scene {
           color: '#ffffff',
         })
         .setOrigin(0.5)
-        .setInteractive({ useHandCursor: true });
+        .setInteractive({ useHandCursor: true })
+        .setDepth(1);
       this.newMatchText.on('pointerup', () => {
         this.scene.stop('Match');
         this.scene.start('SelectBoxer');
@@ -199,7 +203,8 @@ export class OverlayUI extends Phaser.Scene {
           color: '#ffffff',
         })
         .setOrigin(0.5)
-        .setInteractive({ useHandCursor: true });
+        .setInteractive({ useHandCursor: true })
+        .setDepth(1);
       this.rankingText.on('pointerup', () => {
         this.scene.stop('Match');
         this.scene.start('Ranking');
@@ -220,7 +225,8 @@ export class OverlayUI extends Phaser.Scene {
           color: '#ffffff',
         })
         .setOrigin(0.5)
-        .setInteractive({ useHandCursor: true });
+        .setInteractive({ useHandCursor: true })
+        .setDepth(1);
       this.nextRoundText.on('pointerup', () => {
         this.nextRoundText.setVisible(false);
         eventBus.emit('next-round');


### PR DESCRIPTION
## Summary
- Keep overlay scene above the match scene to prevent boxers from hiding UI buttons
- Bring overlay to the front when announcing a winner and give buttons higher depth

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68967c97b4b0832ab31c91f3c02bd6da