### PR TITLE
Position post-match buttons below distance debug text

### DIFF
--- a/src/scripts/overlay.js
+++ b/src/scripts/overlay.js
@@ -194,9 +194,10 @@ export class OverlayUI extends Phaser.Scene {
     this.scene.bringToTop();
     const width = this.sys.game.config.width;
     const height = this.sys.game.config.height;
+    const startY = height - 60;
     if (!this.newMatchText) {
       this.newMatchText = this.add
-        .text(width / 2, height / 2, 'Start New Match', {
+        .text(width / 2, startY, 'Start New Match', {
           font: '32px Arial',
           color: '#ffffff',
         })
@@ -208,12 +209,12 @@ export class OverlayUI extends Phaser.Scene {
         this.scene.start('SelectBoxer');
       });
     } else {
-      this.newMatchText.setVisible(true);
+      this.newMatchText.setVisible(true).setPosition(width / 2, startY);
     }
 
     if (!this.rankingText) {
       this.rankingText = this.add
-        .text(width / 2, height / 2 + 40, 'Show ranking', {
+        .text(width / 2, startY + 40, 'Show ranking', {
           font: '32px Arial',
           color: '#ffffff',
         })
@@ -225,7 +226,9 @@ export class OverlayUI extends Phaser.Scene {
         this.scene.start('Ranking');
       });
     } else {
-      this.rankingText.setVisible(true);
+      this.rankingText
+        .setVisible(true)
+        .setPosition(width / 2, startY + 40);
     }
   }
 


### PR DESCRIPTION
## Summary
- Ensure post-match buttons are visible by moving them below the distance debug text
- Reposition existing buttons whenever a match ends so they remain accessible

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68973a5cb850832a8985cf9e260f2817