### PR TITLE
Move final-round strategy rule into ruleset managers

### DIFF
--- a/src/scripts/match-scene.js
+++ b/src/scripts/match-scene.js
@@ -213,37 +213,6 @@ export class MatchScene extends Phaser.Scene {
     if (currentSecond !== this.lastSecond && currentSecond < this.roundLength) {
       this.ruleManager1.evaluate(currentSecond);
       this.ruleManager2.evaluate(currentSecond);
-      // If one minute remains in the final round, force the boxer who is
-      // trailing on points to switch to the most aggressive strategy. The
-      // existing rule limiting strategy changes still applies.
-      if (
-        this.roundTimer.round === this.maxRounds &&
-        this.roundTimer.remaining === 60
-      ) {
-        let behind = null;
-        if (this.hits.p1 === this.hits.p2) {
-          if (this.player1.health < this.player2.health) behind = this.player1;
-          else if (this.player2.health < this.player1.health)
-            behind = this.player2;
-        } else {
-          behind = this.hits.p1 < this.hits.p2 ? this.player1 : this.player2;
-        }
-        if (behind) {
-          const mgr = behind === this.player1 ? this.ruleManager1 : this.ruleManager2;
-          const ctrl = behind.controller;
-          if (
-            typeof ctrl.setLevel === 'function' &&
-            mgr.canShift(currentSecond)
-          ) {
-            showComment(
-              behind.stats.name +
-                ' knows he is losing and is now pushing desperately.',
-              true
-            );
-            ctrl.setLevel(10);
-          }
-        }
-      }
       this.lastSecond = currentSecond;
     }
 

--- a/src/scripts/ruleset1-manager.js
+++ b/src/scripts/ruleset1-manager.js
@@ -69,6 +69,47 @@ export class RuleSet1Manager {
 
       const aSelf = getActions();
 
+      const scene = this.self.scene;
+      if (
+        scene.roundTimer.round === scene.maxRounds &&
+        scene.roundTimer.remaining === 60
+      ) {
+        const hits = scene.hits;
+        let behind = null;
+        if (hits.p1 === hits.p2) {
+          if (scene.player1.health < scene.player2.health) behind = scene.player1;
+          else if (scene.player2.health < scene.player1.health)
+            behind = scene.player2;
+        } else {
+          behind = hits.p1 < hits.p2 ? scene.player1 : scene.player2;
+        }
+        const leading = behind === scene.player1 ? scene.player2 : scene.player1;
+        if (this.self === behind) {
+          const ctrl = this.self.controller;
+          if (
+            typeof ctrl.setLevel === 'function' &&
+            this.canShift(currentSecond)
+          ) {
+            showComment(
+              this.self.stats.name +
+                ' knows he is losing and is now pushing desperately.',
+              true
+            );
+            ctrl.setLevel(10);
+          }
+        } else if (this.self === leading) {
+          if (aSelf)
+            this.fill(aSelf, currentSecond, [
+              { back: true },
+              { back: true },
+              { block: true },
+            ]);
+          this.activeRule = 'protect-lead';
+          this.activeUntil = currentSecond + 3;
+          return;
+        }
+      }
+
       if (dist < 152) {
         const hSelf = this.self.health / this.self.maxHealth;
         const hOpp = this.opp.health / this.opp.maxHealth;

--- a/src/scripts/ruleset2-manager.js
+++ b/src/scripts/ruleset2-manager.js
@@ -69,6 +69,47 @@ export class RuleSet2Manager {
 
       const aSelf = getActions();
 
+      const scene = this.self.scene;
+      if (
+        scene.roundTimer.round === scene.maxRounds &&
+        scene.roundTimer.remaining === 60
+      ) {
+        const hits = scene.hits;
+        let behind = null;
+        if (hits.p1 === hits.p2) {
+          if (scene.player1.health < scene.player2.health) behind = scene.player1;
+          else if (scene.player2.health < scene.player1.health)
+            behind = scene.player2;
+        } else {
+          behind = hits.p1 < hits.p2 ? scene.player1 : scene.player2;
+        }
+        const leading = behind === scene.player1 ? scene.player2 : scene.player1;
+        if (this.self === behind) {
+          const ctrl = this.self.controller;
+          if (
+            typeof ctrl.setLevel === 'function' &&
+            this.canShift(currentSecond)
+          ) {
+            showComment(
+              this.self.stats.name +
+                ' knows he is losing and is now pushing desperately.',
+              true
+            );
+            ctrl.setLevel(10);
+          }
+        } else if (this.self === leading) {
+          if (aSelf)
+            this.fill(aSelf, currentSecond, [
+              { back: true },
+              { none: true },
+              { block: true },
+            ]);
+          this.activeRule = 'protect-lead';
+          this.activeUntil = currentSecond + 3;
+          return;
+        }
+      }
+
       if (dist < 152) {
         const hSelf = this.self.health / this.self.maxHealth;
         const hOpp = this.opp.health / this.opp.maxHealth;

--- a/src/scripts/ruleset3-manager.js
+++ b/src/scripts/ruleset3-manager.js
@@ -69,6 +69,47 @@ export class RuleSet3Manager {
 
       const aSelf = getActions();
 
+      const scene = this.self.scene;
+      if (
+        scene.roundTimer.round === scene.maxRounds &&
+        scene.roundTimer.remaining === 60
+      ) {
+        const hits = scene.hits;
+        let behind = null;
+        if (hits.p1 === hits.p2) {
+          if (scene.player1.health < scene.player2.health) behind = scene.player1;
+          else if (scene.player2.health < scene.player1.health)
+            behind = scene.player2;
+        } else {
+          behind = hits.p1 < hits.p2 ? scene.player1 : scene.player2;
+        }
+        const leading = behind === scene.player1 ? scene.player2 : scene.player1;
+        if (this.self === behind) {
+          const ctrl = this.self.controller;
+          if (
+            typeof ctrl.setLevel === 'function' &&
+            this.canShift(currentSecond)
+          ) {
+            showComment(
+              this.self.stats.name +
+                ' knows he is losing and is now pushing desperately.',
+              true
+            );
+            ctrl.setLevel(10);
+          }
+        } else if (this.self === leading) {
+          if (aSelf)
+            this.fill(aSelf, currentSecond, [
+              { back: true },
+              { block: true },
+              { block: true },
+            ]);
+          this.activeRule = 'protect-lead';
+          this.activeUntil = currentSecond + 3;
+          return;
+        }
+      }
+
       if (dist < 152) {
         const hSelf = this.self.health / this.self.maxHealth;
         const hOpp = this.opp.health / this.opp.maxHealth;


### PR DESCRIPTION
## Summary
- Delegate per-round strategy evaluation to ruleset managers only
- Add final round logic to switch losing boxer to strategy 10
- Introduce defensive rule for the leading boxer

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68974606aa64832ab0e7252e673e4c50