### PR TITLE
fix: set DOM container for Phaser

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -6,6 +6,7 @@
   <script src="https://cdn.jsdelivr.net/npm/phaser@3/dist/phaser.min.js"></script>
 </head>
 <body>
+  <div id="game-container"></div>
   <script type="module" src="scripts/main.js"></script>
 </body>
 </html>

--- a/src/scripts/main.js
+++ b/src/scripts/main.js
@@ -109,6 +109,7 @@ const config = {
   width: 1024,
   height: 768,
   backgroundColor: '#2d2d2d',
+  parent: 'game-container',
   dom: { createContainer: true },
   scene: [
     BootScene,


### PR DESCRIPTION
## Summary
- define a DOM parent container and bind Phaser to it

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689764f563ac832a871d44cf995af54b