### PR TITLE
Refactor boxer creation dialog

### DIFF
--- a/src/scripts/create-boxer-scene.js
+++ b/src/scripts/create-boxer-scene.js
@@ -11,26 +11,28 @@ export class CreateBoxerScene extends Phaser.Scene {
     const width = this.sys.game.config.width;
     const height = this.sys.game.config.height;
 
+    const maxNameLen = BOXERS.reduce((m, b) => Math.max(m, b.name.length), 0);
+    const inputSize = Math.max(12, maxNameLen);
+
     const formHTML = `
       <form id="boxerForm" style="color:white">
-        <div><label>Name <input type="text" id="name" /></label></div>
-        <div><label>Nickname <input type="text" id="nick" /></label></div>
-        <div><label>Country <input type="text" id="country" /></label></div>
-        <div><label>Age <input type="number" id="age" min="18" max="30" value="18" /></label></div>
-        <div><label>Difficulty
-          <select id="difficulty">
-            <option value="easy">Easy</option>
-            <option value="normal">Normal</option>
-            <option value="hard">Hard</option>
-          </select>
-        </label></div>
-        <div><label>Ruleset <select id="ruleset"></select></label></div>
-        <div>Points left: <span id="points">0</span></div>
-        <div><label>Health <input type="range" id="health" min="0" max="3" step="0.1" value="0" /></label></div>
-        <div><label>Stamina <input type="range" id="stamina" min="0" max="3" step="0.1" value="0" /></label></div>
-        <div><label>Power <input type="range" id="power" min="0" max="3" step="0.1" value="0" /></label></div>
-        <div><label>Speed <input type="range" id="speed" min="0" max="3" step="0.1" value="0" /></label></div>
-        <div style="margin-top:10px"><button type="button" id="createBtn">Create</button></div>
+        <table>
+          <tr><th colspan="2">Boxer</th></tr>
+          <tr><td>Name</td><td><input type="text" id="name" size="${inputSize}" /></td></tr>
+          <tr><td>Nickname</td><td><input type="text" id="nick" size="${inputSize}" /></td></tr>
+          <tr><td>Country</td><td><input type="text" id="country" size="${inputSize}" /></td></tr>
+          <tr><td>Age <span id="ageVal">18</span></td><td><input type="range" id="age" min="18" max="30" value="18" /></td></tr>
+          <tr><th colspan="2">Difficulty &amp; Ruleset</th></tr>
+          <tr><td>Difficulty <span id="diffText">Easy</span></td><td><input type="range" id="difficulty" min="0" max="2" step="1" value="0" /></td></tr>
+          <tr><td>Ruleset</td><td><select id="ruleset"></select></td></tr>
+          <tr><th colspan="2">Attributes</th></tr>
+          <tr><td colspan="2">Points left: <span id="points">0</span></td></tr>
+          <tr><td>Health</td><td><input type="range" id="health" min="0" max="3" step="0.1" value="0" /></td></tr>
+          <tr><td>Stamina</td><td><input type="range" id="stamina" min="0" max="3" step="0.1" value="0" /></td></tr>
+          <tr><td>Power</td><td><input type="range" id="power" min="0" max="3" step="0.1" value="0" /></td></tr>
+          <tr><td>Speed</td><td><input type="range" id="speed" min="0" max="3" step="0.1" value="0" /></td></tr>
+          <tr><td colspan="2" style="text-align:center;padding-top:10px"><button type="button" id="createBtn">Create</button></td></tr>
+        </table>
       </form>
     `;
 
@@ -40,7 +42,9 @@ export class CreateBoxerScene extends Phaser.Scene {
     const nickInput = dom.getChildByID('nick');
     const countryInput = dom.getChildByID('country');
     const ageInput = dom.getChildByID('age');
-    const diffSelect = dom.getChildByID('difficulty');
+    const ageVal = dom.getChildByID('ageVal');
+    const diffSlider = dom.getChildByID('difficulty');
+    const diffText = dom.getChildByID('diffText');
     const rulesetSelect = dom.getChildByID('ruleset');
     const pointsSpan = dom.getChildByID('points');
     const healthSlider = dom.getChildByID('health');
@@ -48,11 +52,17 @@ export class CreateBoxerScene extends Phaser.Scene {
     const powerSlider = dom.getChildByID('power');
     const speedSlider = dom.getChildByID('speed');
     const sliders = [healthSlider, staminaSlider, powerSlider, speedSlider];
+    const lastValues = new Map();
+    sliders.forEach((s) => lastValues.set(s, s.value));
+
+    function currentDifficulty() {
+      return ['easy', 'normal', 'hard'][parseInt(diffSlider.value, 10)];
+    }
 
     function allowedPoints() {
       const age = parseInt(ageInput.value) || 18;
       const over = Math.max(0, age - 18);
-      switch (diffSelect.value) {
+      switch (currentDifficulty()) {
         case 'easy':
           return 6 + over * 0.3;
         case 'normal':
@@ -64,7 +74,7 @@ export class CreateBoxerScene extends Phaser.Scene {
     }
 
     function updateRulesets() {
-      const diff = diffSelect.value;
+      const diff = currentDifficulty();
       rulesetSelect.innerHTML = '';
       const addOpt = (v) => {
         const o = document.createElement('option');
@@ -81,9 +91,29 @@ export class CreateBoxerScene extends Phaser.Scene {
       pointsSpan.textContent = (total - spent).toFixed(1);
     }
 
-    diffSelect.addEventListener('change', () => { updateRulesets(); updatePoints(); });
-    ageInput.addEventListener('input', () => { updatePoints(); });
-    sliders.forEach((s) => s.addEventListener('input', updatePoints));
+    diffSlider.addEventListener('input', () => {
+      diffText.textContent = ['Easy', 'Normal', 'Hard'][parseInt(diffSlider.value, 10)];
+      updateRulesets();
+      updatePoints();
+    });
+
+    ageInput.addEventListener('input', () => {
+      ageVal.textContent = ageInput.value;
+      updatePoints();
+    });
+
+    sliders.forEach((s) => s.addEventListener('input', () => {
+      const prev = parseFloat(lastValues.get(s));
+      const curr = parseFloat(s.value);
+      const total = allowedPoints();
+      const spent = sliders.reduce((sum, el) => sum + parseFloat(el.value), 0);
+      if (spent > total && curr > prev) {
+        s.value = prev;
+      } else {
+        lastValues.set(s, s.value);
+      }
+      updatePoints();
+    }));
 
     updateRulesets();
     updatePoints();


### PR DESCRIPTION
## Summary
- Restructure boxer creation form into grouped table layout
- Add age and difficulty range sliders with dynamic labels
- Enforce point budget and prevent stat increases when out of points

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68976d1749c4832a9ace6dac7ec5bae3