### PR TITLE
Ensure post-match options always appear and add ranking fallback

### DIFF
--- a/src/scripts/select-boxer-scene.js
+++ b/src/scripts/select-boxer-scene.js
@@ -166,12 +166,15 @@ export class SelectBoxerScene extends Phaser.Scene {
     });
     this.options.push(headerText);
     const player = getPlayerBoxer();
-    const boxers = allBoxers.filter(
-      (b) =>
-        b !== player &&
-        b.ranking < player.ranking &&
-        b.ranking >= player.ranking - 3
-    );
+    const boxers = allBoxers.filter((b) => {
+      if (b === player) return false;
+      // Allow facing any lower-ranked boxer but limit higher-ranked
+      // opponents to within three positions above the player.
+      if (b.ranking < player.ranking) {
+        return b.ranking >= player.ranking - 3;
+      }
+      return true;
+    });
     boxers.forEach((b, i) => {
       const y = 80 + i * 24;
       this.options.push(


### PR DESCRIPTION
## Summary
- Keep overlay scene above match and clear any stale handlers when a new match starts
- Add Enter key and general click fallback to show ranking if post-match buttons fail
- Let players challenge any lower-ranked boxer while limiting higher-ranked foes to three spots above

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689775f91db0832aa24440d10395f2b8