### PR TITLE
feat: persist boxer rankings and stats

### DIFF
--- a/src/scripts/boxer-data.js
+++ b/src/scripts/boxer-data.js
@@ -191,3 +191,12 @@ export const BOXERS = [
 export function addBoxer(boxer) {
   BOXERS.push(boxer);
 }
+
+// Snapshot of the initial boxer data for resets.
+const DEFAULT_BOXERS = BOXERS.map((b) => ({ ...b }));
+
+// Restore boxer data to the original defaults.
+export function resetBoxers() {
+  BOXERS.length = 0;
+  DEFAULT_BOXERS.forEach((b) => BOXERS.push({ ...b }));
+}

--- a/src/scripts/match-scene.js
+++ b/src/scripts/match-scene.js
@@ -13,6 +13,8 @@ import { RuleSet3Manager } from './ruleset3-manager.js';
 import { CommentManager } from './comment-manager.js';
 import { showComment } from './comment-manager.js';
 import { recordResult, recordDraw } from './boxer-stats.js';
+import { BOXERS } from './boxer-data.js';
+import { saveGameState } from './save-system.js';
 
 export class MatchScene extends Phaser.Scene {
   constructor() {
@@ -318,6 +320,7 @@ export class MatchScene extends Phaser.Scene {
       round: this.roundTimer.round,
     });
     recordResult(winner.stats, loser.stats, 'KO');
+    saveGameState(BOXERS);
   }
 
   determineWinnerByPoints() {
@@ -334,6 +337,7 @@ export class MatchScene extends Phaser.Scene {
         round: this.roundTimer.round,
       });
       recordDraw(this.player1.stats, this.player2.stats);
+      saveGameState(BOXERS);
       return;
     }
 
@@ -355,6 +359,7 @@ export class MatchScene extends Phaser.Scene {
       round: this.roundTimer.round,
     });
     recordResult(winner.stats, loser.stats, 'Points');
+    saveGameState(BOXERS);
   }
 
   setPlayerStrategy(player, level) {

--- a/src/scripts/ranking-scene.js
+++ b/src/scripts/ranking-scene.js
@@ -2,6 +2,12 @@ import { getRankings } from './boxer-stats.js';
 import { appConfig, getTestMode, setTestMode } from './config.js';
 import { getPlayerBoxer } from './player-boxer.js';
 import { SoundManager } from './sound-manager.js';
+import {
+  loadGameState,
+  applyLoadedState,
+  migrateIfNeeded,
+  resetSavedData,
+} from './save-system.js';
 
 export class RankingScene extends Phaser.Scene {
   constructor() {
@@ -11,6 +17,12 @@ export class RankingScene extends Phaser.Scene {
   create() {
     const width = this.sys.game.config.width;
     SoundManager.playMenuLoop();
+
+    // Load any saved boxer stats before rendering the list.
+    const loaded = loadGameState();
+    if (loaded) {
+      applyLoadedState(migrateIfNeeded(loaded));
+    }
 
     // Show application name and version at the top
     const infoY = 20;
@@ -83,6 +95,25 @@ export class RankingScene extends Phaser.Scene {
           this.scene.start('SelectBoxer');
         } else {
           this.scene.start('CreateBoxer');
+        }
+      });
+
+    // Button to reset saved rankings and stats.
+    this.add
+      .text(tableLeft, startBtn.y + 40, 'Reset data', {
+        font: '20px Arial',
+        color: '#ff0000',
+      })
+      .setOrigin(0, 0)
+      .setInteractive({ useHandCursor: true })
+      .on('pointerup', () => {
+        if (
+          window.confirm(
+            'This will erase saved rankings and stats. Continue?'
+          )
+        ) {
+          resetSavedData();
+          this.scene.restart();
         }
       });
 

--- a/src/scripts/save-system.js
+++ b/src/scripts/save-system.js
@@ -1,0 +1,83 @@
+import { BOXERS, resetBoxers } from './boxer-data.js';
+import { setPlayerBoxer } from './player-boxer.js';
+
+const SAVE_KEY = 'theBoxer.save.v1';
+const VERSION = 1;
+
+// Load the game state from localStorage.
+export function loadGameState() {
+  if (typeof localStorage === 'undefined') return null;
+  try {
+    const raw = localStorage.getItem(SAVE_KEY);
+    if (!raw) return null;
+    const data = JSON.parse(raw);
+    if (data.version !== VERSION || !Array.isArray(data.boxers)) {
+      return null;
+    }
+    return data;
+  } catch (err) {
+    console.warn('Failed to load saved game state', err);
+    return null;
+  }
+}
+
+// Save current boxer rankings and stats to localStorage.
+export function saveGameState(boxers) {
+  if (typeof localStorage === 'undefined') return;
+  try {
+    const payload = {
+      version: VERSION,
+      lastUpdatedUtc: new Date().toISOString(),
+      boxers: boxers.map((b) => ({
+        id: b.name,
+        ranking: b.ranking,
+        matches: b.matches,
+        wins: b.wins,
+        losses: b.losses,
+        draws: b.draws,
+        winsByKO: b.winsByKO,
+      })),
+    };
+    localStorage.setItem(SAVE_KEY, JSON.stringify(payload));
+  } catch (err) {
+    // Ignore errors (e.g. storage unavailable)
+  }
+}
+
+// Apply loaded state to the in-memory boxer registry.
+export function applyLoadedState(state) {
+  if (!state || !Array.isArray(state.boxers)) return;
+  state.boxers.forEach((saved) => {
+    const boxer = BOXERS.find((b) => b.name === saved.id);
+    if (!boxer) return;
+    boxer.ranking = saved.ranking ?? boxer.ranking;
+    boxer.matches = saved.matches ?? boxer.matches;
+    boxer.wins = saved.wins ?? boxer.wins;
+    boxer.losses = saved.losses ?? boxer.losses;
+    boxer.draws = saved.draws ?? boxer.draws;
+    boxer.winsByKO = saved.winsByKO ?? boxer.winsByKO;
+  });
+}
+
+// Remove saved data and restore defaults.
+export function resetSavedData() {
+  if (typeof localStorage !== 'undefined') {
+    try {
+      localStorage.removeItem(SAVE_KEY);
+    } catch (err) {
+      // Ignore
+    }
+  }
+  resetBoxers();
+  setPlayerBoxer(null);
+}
+
+// Placeholder for future migration logic.
+export function migrateIfNeeded(state) {
+  if (!state) return state;
+  if (state.version !== VERSION) {
+    // Future versions can transform the state here.
+    return state; // No migrations yet
+  }
+  return state;
+}


### PR DESCRIPTION
## Summary
- add save system backed by localStorage
- load saved boxer rankings on start and provide reset button
- auto-save boxer stats after each match

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6897964969d8832abe2a868b4f8d1201