### PR TITLE
Improve match setup flow and display location info

### DIFF
--- a/src/scripts/match-scene.js
+++ b/src/scripts/match-scene.js
@@ -125,8 +125,32 @@ export class MatchScene extends Phaser.Scene {
         const [day, month] = ds.split(' ');
         dateStr = `${day} ${month.charAt(0).toUpperCase()}${month.slice(1)}`;
       }
-      const hour = Phaser.Math.Between(0, 23);
-      const minute = Phaser.Math.Between(0, 59);
+      const prestige = data?.arena?.Prestige || 1;
+      const getTime = (prest) => {
+        let start;
+        let end;
+        switch (prest) {
+          case 1:
+            start = 12 * 60;
+            end = 15 * 60;
+            break;
+          case 2:
+            start = 15 * 60 + 30;
+            end = 18 * 60 + 30;
+            break;
+          case 3:
+            start = 19 * 60;
+            end = 23 * 60 + 30;
+            break;
+          default:
+            start = 12 * 60;
+            end = 15 * 60;
+        }
+        const steps = Math.floor((end - start) / 30);
+        const total = start + Phaser.Math.Between(0, steps) * 30;
+        return { hour: Math.floor(total / 60), minute: total % 60 };
+      };
+      const { hour, minute } = getTime(prestige);
       const timeDisplay = `${hour.toString().padStart(2, '0')}:${minute
         .toString()
         .padStart(2, '0')}`;
@@ -135,12 +159,15 @@ export class MatchScene extends Phaser.Scene {
         date: dateStr,
         rank: user.ranking,
         opponentRank: opponent.ranking,
-        arena: data?.arena?.Name,
+        arena: data?.arena,
       };
       eventBus.emit('match-date', {
         date: dateStr,
         year,
         time: timeDisplay,
+        arena: data?.arena?.Name || '',
+        city: data?.arena?.City || '',
+        country: data?.arena?.Country || '',
       });
     } else {
       this.matchMeta = null;

--- a/src/scripts/overlay.js
+++ b/src/scripts/overlay.js
@@ -12,12 +12,13 @@ export class OverlayUI extends Phaser.Scene {
     this.strategyOptions = [];
     this.enterHandler = null;
     this.clickHandler = null;
+    this.locationText = null;
   }
 
   create() {
     const width = this.sys.game.config.width;
     const infoY = 0;
-    const infoHeight = 120;
+    const infoHeight = 140;
     this.add
       .rectangle(width / 2, infoY, width, infoHeight, 0x808080, 0.5)
       .setOrigin(0.5, 0);
@@ -48,7 +49,14 @@ export class OverlayUI extends Phaser.Scene {
     });
     this.dateText.setOrigin(0.5, 0);
 
-    this.roundText = this.add.text(width / 2, infoY + 90, '', {
+    // arena location displayed under the date
+    this.locationText = this.add.text(width / 2, infoY + 86, '', {
+      font: '18px Arial',
+      color: '#ffffff',
+    });
+    this.locationText.setOrigin(0.5, 0);
+
+    this.roundText = this.add.text(width / 2, infoY + 110, '', {
       font: '24px Arial',
       color: '#ffffff',
     });
@@ -140,9 +148,13 @@ export class OverlayUI extends Phaser.Scene {
       this.hitText.p2.setText(`Hits: ${p2}`);
     };
 
-    this.onMatchDate = ({ date, year, time }) => {
+    this.onMatchDate = ({ date, year, time, arena, city, country }) => {
       if (this.dateText) {
         this.dateText.setText(`${date} ${year} ${time}`);
+      }
+      if (this.locationText) {
+        const parts = [arena, city, country].filter((v) => v).join(', ');
+        this.locationText.setText(parts);
       }
     };
 

--- a/src/scripts/ranking-scene.js
+++ b/src/scripts/ranking-scene.js
@@ -127,7 +127,7 @@ export class RankingScene extends Phaser.Scene {
       const btnLabel = getTestMode()
         ? 'Start new game'
         : hasPlayer
-        ? 'Start next match'
+        ? 'Setup next fight'
         : 'Start new game';
       const tableRight = tableLeft + rectWidth;
       const startBtn = this.add


### PR DESCRIPTION
## Summary
- Rename ranking screen action to "Setup next fight"
- Show arena name, city, and country beneath match date/time
- Generate match times in half-hour increments based on arena prestige

## Testing
- `npm test` *(fails: ENOENT, package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_6897ccd35f50832a95fc1ff00333bec3