### PR TITLE
Display rounds and add strategy click sound

### DIFF
--- a/src/scripts/overlay.js
+++ b/src/scripts/overlay.js
@@ -1,5 +1,6 @@
 import { eventBus } from './event-bus.js';
 import { appConfig } from './config.js';
+import { SoundManager } from './sound-manager.js';
 
 export class OverlayUI extends Phaser.Scene {
   constructor() {
@@ -353,6 +354,7 @@ export class OverlayUI extends Phaser.Scene {
         controller.setLevel(levelValue);
         this.strategyOptions.forEach((o) => o.setColor('#ffffff'));
         txt.setColor('#ffff00');
+        SoundManager.playClick();
       });
       this.strategyOptions.push(txt);
     });

--- a/src/scripts/ranking-scene.js
+++ b/src/scripts/ranking-scene.js
@@ -88,18 +88,24 @@ export class RankingScene extends Phaser.Scene {
       this.add.text(
         tableLeft,
         infoY + 30,
+        `Rounds: ${pending.rounds}`,
+        { font: '20px Arial', color: '#ffffff' }
+      );
+      this.add.text(
+        tableLeft,
+        infoY + 60,
         `${pending.arena.Name}, ${pending.arena.City} (${pending.arena.Country})`,
         { font: '20px Arial', color: '#ffffff' }
       );
       const targetRank = Math.min(pending.boxer1.ranking, pending.boxer2.ranking);
       this.add.text(
         tableLeft,
-        infoY + 60,
+        infoY + 90,
         `Winner of this fight gets ranked as number ${targetRank}.`,
         { font: '20px Arial', color: '#ffffff' }
       );
       this.add
-        .text(tableLeft, infoY + 100, 'Start fight!', {
+        .text(tableLeft, infoY + 130, 'Start fight!', {
           font: '24px Arial',
           color: '#00ff00',
         })


### PR DESCRIPTION
## Summary
- show scheduled rounds on the ranking screen
- play menu click when selecting a strategy between rounds

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6897d47d210c832a805727aa71e0dabf