### PR TITLE
Resume audio context on user gesture

### DIFF
--- a/src/scripts/main.js
+++ b/src/scripts/main.js
@@ -99,7 +99,17 @@ class BootScene extends Phaser.Scene {
   create() {
     console.log('BootScene: preload complete, switching to Ranking');
     SoundManager.init(this);
-    SoundManager.playMenuLoop();
+
+    const gameSound = this.game.sound;
+    const resume = () => {
+      if (gameSound.context.state === 'suspended') {
+        gameSound.context.resume();
+      }
+      SoundManager.playMenuLoop();
+      document.body.removeEventListener('pointerdown', resume);
+    };
+    document.body.addEventListener('pointerdown', resume);
+
     this.scene.start('Ranking');
   }
 }


### PR DESCRIPTION
## Summary
- Resume suspended Web Audio context on first user interaction
- Play menu music only after AudioContext is unlocked

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68986e15ce14832aad106d7d01e8e215