### PR TITLE
Reduce resolution and enforce ring bounds

### DIFF
--- a/src/scripts/boxer.js
+++ b/src/scripts/boxer.js
@@ -121,17 +121,22 @@ export class Boxer {
   }
 
   applyBounds(opponent, prevX, prevY) {
-    const width = this.scene.sys.game.config.width;
-    const height = this.scene.sys.game.config.height;
+    const { width, height } = this.scene.sys.game.config;
+    const bounds = this.scene.ringBounds || {
+      left: 0,
+      right: width,
+      top: 0,
+      bottom: height,
+    };
     this.sprite.x = Phaser.Math.Clamp(
       this.sprite.x,
-      this.sprite.displayWidth / 2,
-      width - this.sprite.displayWidth / 2
+      bounds.left + this.sprite.displayWidth / 2,
+      bounds.right - this.sprite.displayWidth / 2
     );
     this.sprite.y = Phaser.Math.Clamp(
       this.sprite.y,
-      this.sprite.displayHeight / 2,
-      height - this.sprite.displayHeight / 2
+      bounds.top + this.sprite.displayHeight / 2,
+      bounds.bottom - this.sprite.displayHeight / 2
     );
 
     if (opponent) {

--- a/src/scripts/main.js
+++ b/src/scripts/main.js
@@ -117,8 +117,8 @@ class BootScene extends Phaser.Scene {
 // Phaser game configuration
 const config = {
   type: Phaser.AUTO,
-  width: 1600,
-  height: 1200,
+  width: 1400,
+  height: 1050,
   backgroundColor: '#2d2d2d',
   parent: 'game-container',
   dom: { createContainer: true },

--- a/src/scripts/match-scene.js
+++ b/src/scripts/match-scene.js
@@ -28,8 +28,10 @@ export class MatchScene extends Phaser.Scene {
 
     const width = this.sys.game.config.width;
     const height = this.sys.game.config.height;
-    // add ring background sized to 880x660 and centered
-    this.add.image(width / 2, height / 2, 'ring').setDisplaySize(880, 660);
+    const ringWidth = 880;
+    const ringHeight = 660;
+    // add ring background sized to ringWidth x ringHeight and centered
+    this.add.image(width / 2, height / 2, 'ring').setDisplaySize(ringWidth, ringHeight);
 
     // create animations for both boxers
     createBoxerAnimations(this, BOXER_PREFIXES.P1);
@@ -67,9 +69,11 @@ export class MatchScene extends Phaser.Scene {
 
     const centerX = width / 2;
     const centerY = height / 2;
-    const ringWidth = 880; // slightly larger ring
     const ringLeft = centerX - ringWidth / 2;
     const ringRight = centerX + ringWidth / 2;
+    const ringTop = centerY - ringHeight / 2;
+    const ringBottom = centerY + ringHeight / 2;
+    this.ringBounds = { left: ringLeft, right: ringRight, top: ringTop, bottom: ringBottom };
     const startY = centerY - 100; // position boxers a bit higher
 
     this.player1 = new Boxer(


### PR DESCRIPTION
## Summary
- Set Phaser canvas size to 1400x1050
- Store ring boundaries and confine boxers within them

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6898aa58b43c832a8a1f8802f61e2f90