### PR TITLE
Fix arena display and highlight player in ranking

### DIFF
--- a/src/scripts/match-log-scene.js
+++ b/src/scripts/match-log-scene.js
@@ -25,7 +25,25 @@ export class MatchLogScene extends Phaser.Scene {
 
     this.log = getMatchLog();
     this.expandedRows = new Set();
-    this.colX = [20, 90, 170, 260, 430, 630, 720, 800, 880];
+    const tableWidth = width * 0.95;
+    const startX = width * 0.025;
+    const colPercents = [
+      0.05,
+      0.09,
+      0.3,
+      0.08,
+      0.2,
+      0.09,
+      0.06,
+      0.06,
+      0.07,
+    ];
+    let accum = startX;
+    this.colX = colPercents.map((p) => {
+      const x = accum;
+      accum += p * tableWidth;
+      return x;
+    });
     const headerY = 80;
     if (!this.log.length) {
       this.add
@@ -90,10 +108,13 @@ export class MatchLogScene extends Phaser.Scene {
         });
       this.rowObjs.push(toggle);
 
+      const arenaText = [entry.arena?.Name, entry.arena?.City]
+        .filter(Boolean)
+        .join(', ');
       const row = [
         entry.year,
         entry.date,
-        entry.arena || '',
+        arenaText,
         entry.rank,
         `${entry.opponent} (rank ${entry.opponentRank})`,
         entry.result,

--- a/src/scripts/ranking-scene.js
+++ b/src/scripts/ranking-scene.js
@@ -44,6 +44,7 @@ export class RankingScene extends Phaser.Scene {
       .setOrigin(0.5, 0);
 
     const boxers = getRankings();
+    const player = getPlayerBoxer();
     const maxNameLen = boxers.reduce((m, b) => Math.max(m, b.name.length), 4);
     const namePad = Math.max(15, maxNameLen + 1);
     const columnWidths = [5, namePad, 5, 5, 5, 5, 5, 5];
@@ -85,10 +86,12 @@ export class RankingScene extends Phaser.Scene {
         `${b.losses.toString().padEnd(columnWidths[5])}` +
         `${b.draws.toString().padEnd(columnWidths[6])}` +
         `${b.winsByKO.toString().padEnd(columnWidths[7])}`;
+      const isPlayer = player && (b === player || b.name === player.name);
       const txt = this.add
         .text(contentOffsetX, y, line, {
           font: '20px monospace',
-          color: '#ffffff',
+          color: isPlayer ? '#0000ff' : '#ffffff',
+          fontStyle: isPlayer ? 'bold' : 'normal',
         })
         .setOrigin(0, 0);
 
@@ -165,7 +168,6 @@ export class RankingScene extends Phaser.Scene {
 
     // Initialize scrollbar position so the player's boxer is centered if possible
     let initialScroll = 0;
-    const player = getPlayerBoxer();
     if (player) {
       const index = boxers.findIndex((b) => b === player || b.name === player.name);
       if (index >= 0) {


### PR DESCRIPTION
## Summary
- Expand match log table to 95% width and show arena name with city
- Highlight player's boxer in ranking table with bold blue text

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6898b07b9524832ab463173382c02ec9