### PR TITLE
Display round score with hit totals

### DIFF
--- a/src/scripts/match-scene.js
+++ b/src/scripts/match-scene.js
@@ -217,6 +217,7 @@ export class MatchScene extends Phaser.Scene {
       p2: data?.boxer2?.name || '',
     });
     eventBus.emit('hit-update', { p1: 0, p2: 0 });
+    eventBus.emit('score-update', { p1: 0, p2: 0 });
     this.events.on('boxer-ko', (b) => this.handleKO(b));
     this.matchOver = false;
     this.pendingRound = null;
@@ -371,6 +372,7 @@ export class MatchScene extends Phaser.Scene {
         : 10;
     this.score.p1 += p1RoundScore;
     this.score.p2 += p2RoundScore;
+    eventBus.emit('score-update', { p1: this.score.p1, p2: this.score.p2 });
     this.roundLog.push({
       round,
       p1Score: p1RoundScore,

--- a/src/scripts/overlay.js
+++ b/src/scripts/overlay.js
@@ -99,6 +99,20 @@ export class OverlayUI extends Phaser.Scene {
       }),
     };
 
+    // track hits and round-score totals
+    this.hits = { p1: 0, p2: 0 };
+    this.score = { p1: 0, p2: 0 };
+
+    this.updateHitTexts = () => {
+      this.hitText.p1.setText(
+        `Hits: ${this.hits.p1} (${this.score.p1}-${this.score.p2})`
+      );
+      this.hitText.p2.setText(
+        `Hits: ${this.hits.p2} (${this.score.p2}-${this.score.p1})`
+      );
+    };
+    this.updateHitTexts();
+
     // initialize full bars
     this.setBarValue(this.bars.p1.stamina, 1);
     this.setBarValue(this.bars.p1.power, 1);
@@ -145,8 +159,13 @@ export class OverlayUI extends Phaser.Scene {
       this.announceWinner(data);
     };
     this.onHitUpdate = ({ p1, p2 }) => {
-      this.hitText.p1.setText(`Hits: ${p1}`);
-      this.hitText.p2.setText(`Hits: ${p2}`);
+      this.hits = { p1, p2 };
+      this.updateHitTexts();
+    };
+
+    this.onScoreUpdate = ({ p1, p2 }) => {
+      this.score = { p1, p2 };
+      this.updateHitTexts();
     };
 
     this.onMatchDate = ({ date, year, time, arena, city, country }) => {
@@ -168,6 +187,7 @@ export class OverlayUI extends Phaser.Scene {
     eventBus.on('round-ended', this.onRoundEnded);
     eventBus.on('match-winner', this.onMatchWinner);
     eventBus.on('hit-update', this.onHitUpdate);
+    eventBus.on('score-update', this.onScoreUpdate);
     eventBus.on('match-date', this.onMatchDate);
 
     this.events.once(Phaser.Scenes.Events.SHUTDOWN, () => {
@@ -180,6 +200,7 @@ export class OverlayUI extends Phaser.Scene {
       eventBus.off('round-ended', this.onRoundEnded);
       eventBus.off('match-winner', this.onMatchWinner);
       eventBus.off('hit-update', this.onHitUpdate);
+      eventBus.off('score-update', this.onScoreUpdate);
       eventBus.off('match-date', this.onMatchDate);
     });
   }


### PR DESCRIPTION
## Summary
- show cumulative round score next to hit counts for each boxer
- emit and listen for new score-update events to keep display in sync

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6898b4512884832aa410e7b21ce5ba45