### PR TITLE
Add continent selection when creating boxer

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Press `Shift` + `P` to pause the match.
 Select **Start new game** on the ranking screen to build your own fighter.
 You will be presented with a form where you can customise the boxer:
 
-- **Identity** – Choose the name, nickname, country and age.
+- **Identity** – Choose the name, nickname, country, continent and age.
 - **Difficulty** – Easy, Normal and Hard determine how many attribute points you
   can spend and which rulesets are available.
 - **Ruleset** – Pick the ruleset for your matches. Higher difficulties offer

--- a/src/scripts/create-boxer-scene.js
+++ b/src/scripts/create-boxer-scene.js
@@ -34,6 +34,14 @@ export class CreateBoxerScene extends Phaser.Scene {
           <tr><td>Name</td><td><input type="text" id="name" size="${inputSize}" /></td></tr>
           <tr><td>Nickname</td><td><input type="text" id="nick" size="${inputSize}" /></td></tr>
           <tr><td>Country</td><td><input type="text" id="country" size="${inputSize}" /></td></tr>
+          <tr><td>Continent</td><td><select id="continent">
+            <option value="Africa">Africa</option>
+            <option value="Asia">Asia</option>
+            <option value="Europe">Europe</option>
+            <option value="North America">North America</option>
+            <option value="Oceania">Oceania</option>
+            <option value="South America">South America</option>
+          </select></td></tr>
           <tr><td>Age <span id="ageVal">18</span></td><td><input type="range" id="age" min="18" max="30" value="18" /></td></tr>
           <tr><th colspan="2">Difficulty &amp; Ruleset</th></tr>
           <tr><td>Difficulty <span id="diffText">Easy</span></td><td><input type="range" id="difficulty" min="0" max="2" step="1" value="0" /></td></tr>
@@ -54,6 +62,7 @@ export class CreateBoxerScene extends Phaser.Scene {
     const nameInput = dom.getChildByID('name');
     const nickInput = dom.getChildByID('nick');
     const countryInput = dom.getChildByID('country');
+    const continentSelect = dom.getChildByID('continent');
     const ageInput = dom.getChildByID('age');
     const ageVal = dom.getChildByID('ageVal');
     const diffSlider = dom.getChildByID('difficulty');
@@ -144,6 +153,7 @@ export class CreateBoxerScene extends Phaser.Scene {
         name: nameInput.value || 'Player',
         nickName: nickInput.value || '',
         country: countryInput.value || '',
+        continent: continentSelect.value || '',
         age,
         stamina: parseFloat(staminaSlider.value),
         power: parseFloat(powerSlider.value),


### PR DESCRIPTION
## Summary
- Add continent dropdown to boxer creation form with major world regions
- Save chosen continent in new boxer profiles
- Document continent field in player creation instructions

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/theboxer/package.json')*
- `npm run lint` *(fails: ENOENT: no such file or directory, open '/workspace/theboxer/package.json')*

------
https://chatgpt.com/codex/tasks/task_e_6898cd1335e8832a8a03a2210fe030ef