### PR TITLE
Add boxing title system with initial champions

### DIFF
--- a/src/scripts/boxer-data.js
+++ b/src/scripts/boxer-data.js
@@ -1137,7 +1137,8 @@ export const BOXER_DATA = [
     "winsByKO": 10,
     "age": 22,
     "defaultStrategy": 5,
-    "ruleset": 1
+    "ruleset": 1,
+    "titles": ["OPBF"]
   },
   {
     "name": "Great Tiger",
@@ -1441,7 +1442,8 @@ export const BOXER_DATA = [
     "winsByKO": 3,
     "age": 30,
     "defaultStrategy": 3,
-    "ruleset": 2
+    "ruleset": 2,
+    "titles": ["SABC"]
   },
   {
     "name": "George Baker",
@@ -1612,7 +1614,8 @@ export const BOXER_DATA = [
     "winsByKO": 2,
     "age": 22,
     "defaultStrategy": 5,
-    "ruleset": 2
+    "ruleset": 2,
+    "titles": ["NABF"]
   },
   {
     "name": "George Johnson",
@@ -1631,7 +1634,8 @@ export const BOXER_DATA = [
     "winsByKO": 4,
     "age": 18,
     "defaultStrategy": 3,
-    "ruleset": 1
+    "ruleset": 1,
+    "titles": ["ABU"]
   },
   {
     "name": "Ray Lopez",
@@ -1707,7 +1711,8 @@ export const BOXER_DATA = [
     "winsByKO": 2,
     "age": 24,
     "defaultStrategy": 4,
-    "ruleset": 2
+    "ruleset": 2,
+    "titles": ["EBU"]
   },
   {
     "name": "Mr. Sandman",
@@ -1821,7 +1826,8 @@ export const BOXER_DATA = [
     "winsByKO": 11,
     "age": 37,
     "defaultStrategy": 6,
-    "ruleset": 2
+    "ruleset": 2,
+    "titles": ["IBF"]
   },
   {
     "name": "Cody Jones",
@@ -1897,6 +1903,7 @@ export const BOXER_DATA = [
     "age": 23,
     "ruleset": 3,
     "ranking": 1,
-    "defaultStrategy": 5
+    "defaultStrategy": 5,
+    "titles": ["WBA", "WBC", "WBO"]
   }
 ];

--- a/src/scripts/boxer-stats.js
+++ b/src/scripts/boxer-stats.js
@@ -1,4 +1,10 @@
 import { BOXERS } from './boxers.js';
+import { TITLES } from './title-data.js';
+
+const TITLE_MAP = TITLES.reduce((acc, t) => {
+  acc[t.name] = t;
+  return acc;
+}, {});
 
 // Record a win/loss result between two boxers.
 export function recordResult(winner, loser, method) {
@@ -16,6 +22,7 @@ export function recordResult(winner, loser, method) {
     winner.ranking = loser.ranking;
     loser.ranking = temp;
   }
+  updateTitles(winner, loser);
 }
 
 // Record a draw between two boxers.
@@ -29,5 +36,32 @@ export function recordDraw(boxer1, boxer2) {
 // Get a list of boxers sorted by current ranking.
 export function getRankings() {
   return BOXERS.slice().sort((a, b) => a.ranking - b.ranking);
+}
+
+function updateTitles(winner, loser) {
+  winner.titles = winner.titles || [];
+  loser.titles = loser.titles || [];
+  const allTitles = winner.titles.concat(loser.titles);
+  const hasGlobal = allTitles.some((name) => TITLE_MAP[name]?.region === 'Global');
+
+  if (hasGlobal) {
+    winner.titles = Array.from(new Set(allTitles));
+    loser.titles = [];
+    return;
+  }
+
+  loser.titles = loser.titles.filter((name) => {
+    const info = TITLE_MAP[name];
+    if (
+      info &&
+      info.region !== 'Global' &&
+      winner.continent === info.region &&
+      loser.continent === info.region
+    ) {
+      if (!winner.titles.includes(name)) winner.titles.push(name);
+      return false;
+    }
+    return true;
+  });
 }
 

--- a/src/scripts/create-boxer-scene.js
+++ b/src/scripts/create-boxer-scene.js
@@ -168,6 +168,7 @@ export class CreateBoxerScene extends Phaser.Scene {
         defaultStrategy: defaultStrategyForRanking(ranking),
         ruleset: parseInt(rulesetSelect.value, 10),
         userCreated: true,
+        titles: [],
       };
       addBoxer(boxer);
       setPlayerBoxer(boxer);

--- a/src/scripts/save-system.js
+++ b/src/scripts/save-system.js
@@ -38,6 +38,7 @@ export function saveGameState(boxers) {
           losses: b.losses,
           draws: b.draws,
           winsByKO: b.winsByKO,
+          titles: b.titles || [],
         };
         if (b.userCreated) {
           return {
@@ -92,6 +93,7 @@ export function applyLoadedState(state) {
         defaultStrategy: saved.defaultStrategy ?? 1,
         ruleset: saved.ruleset ?? 1,
         userCreated: true,
+        titles: saved.titles ?? [],
       };
       addBoxer(boxer);
       setPlayerBoxer(boxer);
@@ -104,6 +106,7 @@ export function applyLoadedState(state) {
     boxer.losses = saved.losses ?? boxer.losses;
     boxer.draws = saved.draws ?? boxer.draws;
     boxer.winsByKO = saved.winsByKO ?? boxer.winsByKO;
+    boxer.titles = saved.titles ?? boxer.titles ?? [];
     if (saved.userCreated) {
       boxer.userCreated = true;
       boxer.nickName = saved.nickName ?? boxer.nickName;

--- a/src/scripts/title-data.js
+++ b/src/scripts/title-data.js
@@ -1,4 +1,4 @@
-[
+export const TITLES = [
   {
     "name": "WBA",
     "fullName": "World Boxing Association",
@@ -44,4 +44,4 @@
     "fullName": "Oriental and Pacific Boxing Federation",
     "region": "Asia"
   }
-]
+];


### PR DESCRIPTION
## Summary
- export list of boxing titles
- track and transfer titles after matches
- persist boxer titles and initialize champions

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6898d82e783c832aba1c6d0ebcd083b8