### PR TITLE
feat: add global arena backdrop

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -5,7 +5,14 @@
   <meta http-equiv="Cache-Control" content="no-store, no-cache, must-revalidate, max-age=0">
   <meta http-equiv="Pragma" content="no-cache">
   <meta http-equiv="Expires" content="0">
-  <title>The Boxer</title>  
+  <title>The Boxer</title>
+  <style>
+    body {
+      margin: 0;
+      background: url('assets/arena/backdrop.png') no-repeat center center fixed;
+      background-size: cover;
+    }
+  </style>
   <script src="https://cdn.jsdelivr.net/npm/phaser@3/dist/phaser.min.js"></script>
 </head>
 <body>

--- a/src/scripts/main.js
+++ b/src/scripts/main.js
@@ -119,9 +119,9 @@ const config = {
   type: Phaser.AUTO,
   width: 1400,
   height: 1050,
-  backgroundColor: '#2d2d2d',
   parent: 'game-container',
   dom: { createContainer: true },
+  transparent: true,
   scene: [
     BootScene,
     RankingScene,


### PR DESCRIPTION
## Summary
- display new arena backdrop behind all scenes
- enable transparent Phaser canvas to reveal background image

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open 'package.json')*

------
https://chatgpt.com/codex/tasks/task_e_689909334954832a86f90380cd454c63