### PR TITLE
Make UI tables semi-transparent

### DIFF
--- a/src/scripts/config.js
+++ b/src/scripts/config.js
@@ -3,6 +3,9 @@ export const appConfig = {
   version: '0.0.002'
 };
 
+// Default transparency for UI tables (1.0 = fully opaque)
+export const tableAlpha = 0.7;
+
 // Start the game in non-test mode by default.  The ranking screen
 // provides a checkbox that can enable test mode if needed.
 let testMode = false;

--- a/src/scripts/match-log-scene.js
+++ b/src/scripts/match-log-scene.js
@@ -1,6 +1,7 @@
 import { getMatchLog } from './match-log.js';
 import { SoundManager } from './sound-manager.js';
 import { getPlayerBoxer } from './player-boxer.js';
+import { tableAlpha } from './config.js';
 
 export class MatchLogScene extends Phaser.Scene {
   constructor() {
@@ -27,6 +28,10 @@ export class MatchLogScene extends Phaser.Scene {
     this.expandedRows = new Set();
     const tableWidth = width * 0.95;
     const startX = width * 0.025;
+    const rowHeight = 24;
+    this.tableWidth = tableWidth;
+    this.rowHeight = rowHeight;
+    this.startX = startX;
     const colPercents = [
       0.05,
       0.09,
@@ -45,6 +50,9 @@ export class MatchLogScene extends Phaser.Scene {
       return x;
     });
     const headerY = 80;
+    this.add
+      .rectangle(width / 2, headerY, tableWidth, rowHeight, 0x808080, tableAlpha)
+      .setOrigin(0.5, 0);
     if (!this.log.length) {
       this.add
         .text(width / 2, headerY, 'No matches recorded', {
@@ -70,7 +78,7 @@ export class MatchLogScene extends Phaser.Scene {
           color: '#ffffff',
         });
       });
-      this.startY = headerY + 30;
+      this.startY = headerY + rowHeight + 6;
       this.renderRows();
     }
 
@@ -91,9 +99,16 @@ export class MatchLogScene extends Phaser.Scene {
     }
     this.rowObjs = [];
     let y = this.startY;
+    const width = this.sys.game.config.width;
+    const rowHeight = this.rowHeight;
     this.log.forEach((entry, index) => {
+      const rowRect = this.add
+        .rectangle(width / 2, y, this.tableWidth, rowHeight, 0x808080, tableAlpha)
+        .setOrigin(0.5, 0);
+      this.rowObjs.push(rowRect);
+
       const toggle = this.add
-        .text(5, y, this.expandedRows.has(index) ? '-' : '+', {
+        .text(this.startX - 15, y, this.expandedRows.has(index) ? '-' : '+', {
           font: '20px Arial',
           color: '#00ff00',
         })
@@ -129,7 +144,7 @@ export class MatchLogScene extends Phaser.Scene {
         });
         this.rowObjs.push(obj);
       });
-      y += 24;
+      y += rowHeight;
 
       if (this.expandedRows.has(index) && Array.isArray(entry.roundDetails)) {
         entry.roundDetails.forEach((rd) => {

--- a/src/scripts/ranking-scene.js
+++ b/src/scripts/ranking-scene.js
@@ -1,5 +1,5 @@
 import { getRankings } from './boxer-stats.js';
-import { appConfig, getTestMode, setTestMode } from './config.js';
+import { appConfig, getTestMode, setTestMode, tableAlpha } from './config.js';
 import { getPlayerBoxer } from './player-boxer.js';
 import { SoundManager } from './sound-manager.js';
 import { getPendingMatch, clearPendingMatch } from './next-match.js';
@@ -57,7 +57,7 @@ export class RankingScene extends Phaser.Scene {
     const tableTop = headerY + 40;
     const tableLeft = width * 0.05;
     this.add
-      .rectangle(tableLeft, tableTop, rectWidth, rowHeight, 0x808080, 0.5)
+      .rectangle(tableLeft, tableTop, rectWidth, rowHeight, 0x808080, tableAlpha)
       .setOrigin(0, 0);
     const headers =
       `${'Rank'.padEnd(columnWidths[0])}` +
@@ -89,7 +89,7 @@ export class RankingScene extends Phaser.Scene {
     boxers.forEach((b, i) => {
       const y = startY + i * rowHeight;
       const rowRect = this.add
-        .rectangle(width / 2, y, rectWidth, rowHeight, 0x808080, 0.5)
+        .rectangle(width / 2, y, rectWidth, rowHeight, 0x808080, tableAlpha)
         .setOrigin(0.5, 0);
       const line =
         `${b.ranking.toString().padEnd(columnWidths[0])}` +

--- a/src/scripts/select-boxer-scene.js
+++ b/src/scripts/select-boxer-scene.js
@@ -1,5 +1,5 @@
 import { getRankings } from './boxer-stats.js';
-import { getTestMode } from './config.js';
+import { getTestMode, tableAlpha } from './config.js';
 import { getPlayerBoxer } from './player-boxer.js';
 import { SoundManager } from './sound-manager.js';
 import { scheduleMatch } from './next-match.js';
@@ -65,7 +65,7 @@ export class SelectBoxerScene extends Phaser.Scene {
     const rowHeight = 24;
     this.options.push(
       this.add
-        .rectangle(width / 2, 60, rectWidth, rowHeight, 0x808080, 0.5)
+        .rectangle(width / 2, 60, rectWidth, rowHeight, 0x808080, tableAlpha)
         .setOrigin(0.5, 0)
     );
     const headers = `${'Rank'.padEnd(5)}${'Name'.padEnd(15)}${'Age'.padEnd(5)}${'M'.padEnd(5)}${'W'.padEnd(5)}${'L'.padEnd(5)}${'D'.padEnd(5)}${'KO'.padEnd(5)}`;
@@ -79,7 +79,7 @@ export class SelectBoxerScene extends Phaser.Scene {
       const y = 80 + i * 24;
       this.options.push(
         this.add
-          .rectangle(width / 2, y, rectWidth, rowHeight, 0x808080, 0.5)
+          .rectangle(width / 2, y, rectWidth, rowHeight, 0x808080, tableAlpha)
           .setOrigin(0.5, 0)
       );
       const line = `${b.ranking.toString().padEnd(5)}${b.name.padEnd(15)}${b.age
@@ -157,7 +157,7 @@ export class SelectBoxerScene extends Phaser.Scene {
     const tableLeft = (width - rectWidth) / 2;
     this.options.push(
       this.add
-        .rectangle(width / 2, 60, rectWidth, rowHeight, 0x808080, 0.5)
+        .rectangle(width / 2, 60, rectWidth, rowHeight, 0x808080, tableAlpha)
         .setOrigin(0.5, 0)
     );
     const headers = `${'Rank'.padEnd(columnWidths[0])}${'Name'.padEnd(columnWidths[1])}${'Age'.padEnd(columnWidths[2])}${'M'.padEnd(columnWidths[3])}${'W'.padEnd(columnWidths[4])}${'L'.padEnd(columnWidths[5])}${'D'.padEnd(columnWidths[6])}${'KO'.padEnd(columnWidths[7])}`;
@@ -180,7 +180,7 @@ export class SelectBoxerScene extends Phaser.Scene {
       const y = 80 + i * 24;
       this.options.push(
         this.add
-          .rectangle(width / 2, y, rectWidth, rowHeight, 0x808080, 0.5)
+          .rectangle(width / 2, y, rectWidth, rowHeight, 0x808080, tableAlpha)
           .setOrigin(0.5, 0)
       );
       const line = `${b.ranking.toString().padEnd(columnWidths[0])}${b.name.padEnd(columnWidths[1])}${b.age.toString().padEnd(columnWidths[2])}${b.matches.toString().padEnd(columnWidths[3])}${b.wins.toString().padEnd(columnWidths[4])}${b.losses.toString().padEnd(columnWidths[5])}${b.draws.toString().padEnd(columnWidths[6])}${b.winsByKO.toString().padEnd(columnWidths[7])}`;


### PR DESCRIPTION
## Summary
- add configurable `tableAlpha` for table transparency
- apply the shared opacity to ranking, opponent selection and match log tables

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node --check src/scripts/config.js && node --check src/scripts/ranking-scene.js && node --check src/scripts/select-boxer-scene.js && node --check src/scripts/match-log-scene.js`

------
https://chatgpt.com/codex/tasks/task_e_68990bcb1dac832aac6805c5b6a1a789