### PR TITLE
Format prize money and adjust UI transparency

### DIFF
--- a/src/scripts/comment-manager.js
+++ b/src/scripts/comment-manager.js
@@ -54,7 +54,7 @@ export class CommentManager {
     const bgHeight = this.textObject.height + 10;
 
     this.bgObject = this.scene.add
-      .rectangle(width / 2, y, bgWidth, bgHeight, 0x808080, 0.5)
+      .rectangle(width / 2, y, bgWidth, bgHeight, 0x808080, 0.4)
       .setOrigin(0.5)
       .setDepth(0);
 

--- a/src/scripts/config.js
+++ b/src/scripts/config.js
@@ -4,7 +4,8 @@ export const appConfig = {
 };
 
 // Default transparency for UI tables (1.0 = fully opaque)
-export const tableAlpha = 0.7;
+// Increased by 10% for more transparency
+export const tableAlpha = 0.6;
 
 // Start the game in non-test mode by default.  The ranking screen
 // provides a checkbox that can enable test mode if needed.

--- a/src/scripts/helpers.js
+++ b/src/scripts/helpers.js
@@ -6,3 +6,12 @@ export const BOXER_PREFIXES = {
 export function animKey(prefix, name) {
   return `${prefix}_${name}`;
 }
+
+// Format a numeric amount into a dollar string with space separated thousands
+// e.g. 5000000 -> "$5 000 000". Returns '-' if amount is null or undefined.
+export function formatMoney(amount) {
+  if (amount == null) return '-';
+  return `$${amount
+    .toLocaleString('sv-SE')
+    .replace(/\u00A0/g, ' ')}`;
+}

--- a/src/scripts/match-log-scene.js
+++ b/src/scripts/match-log-scene.js
@@ -2,6 +2,7 @@ import { getMatchLog } from './match-log.js';
 import { SoundManager } from './sound-manager.js';
 import { getPlayerBoxer } from './player-boxer.js';
 import { tableAlpha } from './config.js';
+import { formatMoney } from './helpers.js';
 
 export class MatchLogScene extends Phaser.Scene {
   constructor() {
@@ -138,7 +139,7 @@ export class MatchLogScene extends Phaser.Scene {
         entry.method === 'KO' ? 'KO' : entry.score,
         entry.round,
         entry.method === 'KO' ? entry.time : '-',
-        entry.prize ?? '-',
+        entry.prize != null ? formatMoney(entry.prize) : '-',
       ];
       row.forEach((text, i) => {
         const obj = this.add.text(this.colX[i], y, String(text), {

--- a/src/scripts/match-scene.js
+++ b/src/scripts/match-scene.js
@@ -609,7 +609,7 @@ export class MatchScene extends Phaser.Scene {
         p1Text.width + panelPadding * 2,
         p1Text.height + panelPadding * 2,
         0x808080,
-        0.5
+        0.4
       )
       .setOrigin(0, 0);
     const p2Bg = this.add
@@ -619,7 +619,7 @@ export class MatchScene extends Phaser.Scene {
         p2Text.width + panelPadding * 2,
         p2Text.height + panelPadding * 2,
         0x808080,
-        0.5
+        0.4
       )
       .setOrigin(1, 0);
     p1Text.setDepth(1);

--- a/src/scripts/overlay.js
+++ b/src/scripts/overlay.js
@@ -21,8 +21,9 @@ export class OverlayUI extends Phaser.Scene {
     const width = this.sys.game.config.width;
     const infoY = 0;
     const infoHeight = 140;
+    // Slightly increased transparency for the overlay background
     this.add
-      .rectangle(width / 2, infoY, width, infoHeight, 0x808080, 0.5)
+      .rectangle(width / 2, infoY, width, infoHeight, 0x808080, 0.4)
       .setOrigin(0.5, 0);
 
     // show application name and version
@@ -207,12 +208,14 @@ export class OverlayUI extends Phaser.Scene {
   }
 
   createBar(x, y, width, height, color) {
-    const bg = this.add.rectangle(x, y, width, height, 0x444444).setOrigin(0, 0);
+    const bg = this.add
+      .rectangle(x, y, width, height, 0x444444, 0.9)
+      .setOrigin(0, 0);
     const fill = this.add
-      .rectangle(x + 1, y + 1, width - 2, height - 2, color)
+      .rectangle(x + 1, y + 1, width - 2, height - 2, color, 0.9)
       .setOrigin(0, 0);
     return { bg, fill, width: width - 2 };
-    }
+  }
 
   setBarValue(bar, value) {
     const w = Phaser.Math.Clamp(value, 0, 1) * bar.width;

--- a/src/scripts/ranking-scene.js
+++ b/src/scripts/ranking-scene.js
@@ -1,6 +1,7 @@
 import { getRankings } from './boxer-stats.js';
 import { appConfig, getTestMode, setTestMode, tableAlpha } from './config.js';
 import { getPlayerBoxer } from './player-boxer.js';
+import { formatMoney } from './helpers.js';
 import { SoundManager } from './sound-manager.js';
 import { getPendingMatch, clearPendingMatch } from './next-match.js';
 import {
@@ -47,8 +48,12 @@ export class RankingScene extends Phaser.Scene {
     const player = getPlayerBoxer();
     const maxNameLen = boxers.reduce((m, b) => Math.max(m, b.name.length), 4);
     const namePad = Math.max(15, maxNameLen + 1);
+    const maxPrizeLen = boxers.reduce(
+      (m, b) => Math.max(m, formatMoney(b.earnings || 0).length),
+      6
+    );
     const rectWidth = width * 0.9;
-    const baseColumnWidths = [5, namePad, 5, 5, 5, 5, 5, 5, 8];
+    const baseColumnWidths = [5, namePad, 5, 5, 5, 5, 5, 5, maxPrizeLen];
     const totalChars = Math.floor(rectWidth / 12);
     const baseWidth = baseColumnWidths.reduce((sum, w) => sum + w, 0);
     const titlePad = Math.max(totalChars - baseWidth, 35);
@@ -101,7 +106,7 @@ export class RankingScene extends Phaser.Scene {
         `${b.losses.toString().padEnd(columnWidths[5])}` +
         `${b.draws.toString().padEnd(columnWidths[6])}` +
         `${b.winsByKO.toString().padEnd(columnWidths[7])}` +
-        `${(b.earnings || 0).toString().padEnd(columnWidths[8])}` +
+        `${formatMoney(b.earnings || 0).padEnd(columnWidths[8])}` +
         `${(b.titles ? b.titles.map((t) => `${t}🏆`).join(' ') : '').padEnd(columnWidths[9])}`;
       const isPlayer = player && (b === player || b.name === player.name);
       const txt = this.add

--- a/src/scripts/select-boxer-scene.js
+++ b/src/scripts/select-boxer-scene.js
@@ -61,20 +61,32 @@ export class SelectBoxerScene extends Phaser.Scene {
   showBoxerOptions() {
     this.clearOptions();
     const width = this.sys.game.config.width;
-    const rectWidth = width - 160;
+    const boxers = getRankings();
+    const maxNameLen = boxers.reduce((m, b) => Math.max(m, b.name.length), 4);
+    const columnWidths = [5, Math.max(15, maxNameLen + 1), 5, 5, 5, 5, 5, 5];
+    const charWidth = 12;
+    const rectWidth = columnWidths.reduce((a, c) => a + c, 0) * charWidth;
+    const tableLeft = (width - rectWidth) / 2;
     const rowHeight = 24;
     this.options.push(
       this.add
         .rectangle(width / 2, 60, rectWidth, rowHeight, 0x808080, tableAlpha)
         .setOrigin(0.5, 0)
     );
-    const headers = `${'Rank'.padEnd(5)}${'Name'.padEnd(15)}${'Age'.padEnd(5)}${'M'.padEnd(5)}${'W'.padEnd(5)}${'L'.padEnd(5)}${'D'.padEnd(5)}${'KO'.padEnd(5)}`;
-    const headerText = this.add.text(80, 60, headers, {
+    const headers =
+      `${'Rank'.padEnd(columnWidths[0])}` +
+      `${'Name'.padEnd(columnWidths[1])}` +
+      `${'Age'.padEnd(columnWidths[2])}` +
+      `${'M'.padEnd(columnWidths[3])}` +
+      `${'W'.padEnd(columnWidths[4])}` +
+      `${'L'.padEnd(columnWidths[5])}` +
+      `${'D'.padEnd(columnWidths[6])}` +
+      `${'KO'.padEnd(columnWidths[7])}`;
+    const headerText = this.add.text(tableLeft, 60, headers, {
       font: '20px monospace',
       color: '#ffff00',
     });
     this.options.push(headerText);
-    const boxers = getRankings();
     boxers.forEach((b, i) => {
       const y = 80 + i * 24;
       this.options.push(
@@ -82,16 +94,16 @@ export class SelectBoxerScene extends Phaser.Scene {
           .rectangle(width / 2, y, rectWidth, rowHeight, 0x808080, tableAlpha)
           .setOrigin(0.5, 0)
       );
-      const line = `${b.ranking.toString().padEnd(5)}${b.name.padEnd(15)}${b.age
-        .toString()
-        .padEnd(5)}${b.matches
-        .toString()
-        .padEnd(5)}${b.wins.toString().padEnd(5)}${b.losses
-        .toString()
-        .padEnd(5)}${b.draws
-        .toString()
-        .padEnd(5)}${b.winsByKO.toString().padEnd(5)}`;
-      const txt = this.add.text(80, y, line, {
+      const line =
+        `${b.ranking.toString().padEnd(columnWidths[0])}` +
+        `${b.name.padEnd(columnWidths[1])}` +
+        `${b.age.toString().padEnd(columnWidths[2])}` +
+        `${b.matches.toString().padEnd(columnWidths[3])}` +
+        `${b.wins.toString().padEnd(columnWidths[4])}` +
+        `${b.losses.toString().padEnd(columnWidths[5])}` +
+        `${b.draws.toString().padEnd(columnWidths[6])}` +
+        `${b.winsByKO.toString().padEnd(columnWidths[7])}`;
+      const txt = this.add.text(tableLeft, y, line, {
         font: '20px monospace',
         color: '#ffffff',
       });


### PR DESCRIPTION
## Summary
- display prize money in dollar format with spaced thousands
- size boxer name column dynamically to fit longest name
- lighten UI tables and overlays by 10% transparency

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6899141b8be4832aaa7e4cd226ff0dfa