### PR TITLE
Trigger match intro scene before match

### DIFF
--- a/src/scripts/boxer-stats.js
+++ b/src/scripts/boxer-stats.js
@@ -37,6 +37,36 @@ function beltsOnLine(b1, b2) {
   return titles.size;
 }
 
+function titlesOnLineList(b1, b2) {
+  const titles = new Set();
+  const check = (t) => {
+    const info = TITLE_MAP[t];
+    if (!info) return;
+    if (info.region === 'Global') {
+      titles.add(t);
+    } else if (b1.continent === info.region && b2.continent === info.region) {
+      titles.add(t);
+    }
+  };
+  (b1.titles || []).forEach(check);
+  (b2.titles || []).forEach(check);
+  return Array.from(titles);
+}
+
+export function getMatchPreview(b1, b2) {
+  const titles = titlesOnLineList(b1, b2);
+  const worstRank = Math.max(b1.ranking || 100, b2.ranking || 100);
+  const { base, bonus } = basePrizeForRank(worstRank);
+  const beltMult = Math.pow(3, titles.length);
+  const purse = roundThousand(base * beltMult);
+  const winnerBonus = roundThousand(purse * bonus);
+  return {
+    purse,
+    winnerBonus,
+    titlesOnTheLine: titles.map((code) => ({ code })),
+  };
+}
+
 function awardEarnings(b1, b2, winner) {
   const worstRank = Math.max(b1.ranking || 100, b2.ranking || 100);
   const { base, bonus } = basePrizeForRank(worstRank);

--- a/src/scripts/main.js
+++ b/src/scripts/main.js
@@ -6,6 +6,7 @@ import { SoundManager } from './sound-manager.js';
 import { CreateBoxerScene } from './create-boxer-scene.js';
 import { MatchLogScene } from './match-log-scene.js';
 import { BackdropManager } from './backdrop-manager.js';
+import { MatchIntroScene } from './match-intro-scene.js';
 
 class BootScene extends Phaser.Scene {
   constructor() {
@@ -130,6 +131,7 @@ const config = {
     MatchLogScene,
     CreateBoxerScene,
     SelectBoxerScene,
+    MatchIntroScene,
     MatchScene,
     OverlayUI,
   ],

--- a/src/scripts/match-intro-scene.js
+++ b/src/scripts/match-intro-scene.js
@@ -20,7 +20,8 @@ export class MatchIntroScene extends Phaser.Scene {
       this.skipped = true;
       this.timeline?.stop();
       SoundManager.sounds?.crowd?.stop();
-      this.scene.start('MatchScene', this.matchData);
+      this.scene.launch('OverlayUI');
+      this.scene.start('Match', this.matchData);
     };
     this.input.keyboard.on('keydown', skip);
     this.input.on('pointerdown', skip);

--- a/src/scripts/next-match.js
+++ b/src/scripts/next-match.js
@@ -1,5 +1,6 @@
 import { ArenaManager } from './arena-manager.js';
 import { getMatchLog } from './match-log.js';
+import { getMatchPreview } from './boxer-stats.js';
 
 let pendingMatch = null;
 
@@ -22,6 +23,10 @@ export function scheduleMatch({ boxer1, boxer2, aiLevel1, aiLevel2, rounds }) {
   const highestRank = Math.min(boxer1.ranking, boxer2.ranking);
   const arena = ArenaManager.getRandomArena(highestRank);
   const { year, date } = computeDate();
+  const { purse, winnerBonus, titlesOnTheLine } = getMatchPreview(
+    boxer1,
+    boxer2
+  );
   pendingMatch = {
     boxer1,
     boxer2,
@@ -31,6 +36,9 @@ export function scheduleMatch({ boxer1, boxer2, aiLevel1, aiLevel2, rounds }) {
     arena,
     year,
     date,
+    purse,
+    winnerBonus,
+    titlesOnTheLine,
   };
 }
 

--- a/src/scripts/ranking-scene.js
+++ b/src/scripts/ranking-scene.js
@@ -246,20 +246,13 @@ export class RankingScene extends Phaser.Scene {
         .on('pointerup', () => {
           SoundManager.stopMenuLoop();
           SoundManager.playIntro();
-          this.scene.launch('OverlayUI');
-          const { boxer1, boxer2, aiLevel1, aiLevel2, rounds, arena, year, date } =
-            pending;
+          const matchData = {
+            ...pending,
+            red: pending.boxer1,
+            blue: pending.boxer2,
+          };
           clearPendingMatch();
-          this.scene.start('Match', {
-            boxer1,
-            boxer2,
-            aiLevel1,
-            aiLevel2,
-            rounds,
-            arena,
-            year,
-            date,
-          });
+          this.scene.start('MatchIntroScene', matchData);
         });
     } else {
       const btnLabel = getTestMode()


### PR DESCRIPTION
## Summary
- Register and launch the new MatchIntroScene before matches
- Calculate purse, winner bonus, and titles for intro display
- Start matches from intro scene while initializing OverlayUI

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68991f2f4350832abf48ad98b73e4559