### PR TITLE
Launch MatchIntroScene on round selection and fix emitter API

### DIFF
--- a/src/scripts/match-intro-scene.js
+++ b/src/scripts/match-intro-scene.js
@@ -89,15 +89,14 @@ export class MatchIntroScene extends Phaser.Scene {
       purseContainer.add(bonusText);
     }
 
-    const coins = this.add.particles('coin');
-    const emitter = coins.createEmitter({
+    const emitter = this.add.particles(0, 0, 'coin', {
       speed: { min: -300, max: 300 },
       angle: { min: 0, max: 360 },
       gravityY: 400,
       lifespan: 1500,
       quantity: 30,
       scale: { start: 0.5, end: 0 },
-      on: false,
+      emitting: false,
     });
 
     // belts setup

--- a/src/scripts/select-boxer-scene.js
+++ b/src/scripts/select-boxer-scene.js
@@ -2,7 +2,11 @@ import { getRankings } from './boxer-stats.js';
 import { getTestMode, tableAlpha } from './config.js';
 import { getPlayerBoxer } from './player-boxer.js';
 import { SoundManager } from './sound-manager.js';
-import { scheduleMatch } from './next-match.js';
+import {
+  scheduleMatch,
+  getPendingMatch,
+  clearPendingMatch,
+} from './next-match.js';
 
 export class SelectBoxerScene extends Phaser.Scene {
   constructor() {
@@ -329,7 +333,18 @@ export class SelectBoxerScene extends Phaser.Scene {
       : this.selectedStrategy1 ?? 'default';
     const aiLevel2 = this.selectedStrategy2 ?? 'default';
     scheduleMatch({ boxer1, boxer2, aiLevel1, aiLevel2, rounds });
-    this.scene.start('Ranking');
+    const pending = getPendingMatch();
+    if (pending) {
+      const matchData = {
+        ...pending,
+        red: pending.boxer1,
+        blue: pending.boxer2,
+      };
+      clearPendingMatch();
+      this.scene.start('MatchIntroScene', matchData);
+    } else {
+      this.scene.start('Ranking');
+    }
   }
 
   resetSelection() {


### PR DESCRIPTION
## Summary
- Start MatchIntroScene immediately after the user selects the number of rounds
- Update coin particle emitter to use current Phaser API

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689922651f64832a95e44a88594adfc1