### PR TITLE
Fix MatchIntroScene timeline creation

### DIFF
--- a/src/scripts/match-intro-scene.js
+++ b/src/scripts/match-intro-scene.js
@@ -127,7 +127,7 @@ export class MatchIntroScene extends Phaser.Scene {
       .setAlpha(0);
 
     // timeline
-    const timeline = this.tweens.createTimeline();
+    const timeline = this.tweens.timeline();
     this.timeline = timeline;
 
     timeline.add({


### PR DESCRIPTION
## Summary
- Replace deprecated `this.tweens.createTimeline()` with `this.tweens.timeline()` in MatchIntroScene to prevent runtime error during initialization.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6899236f9008832aab152b4f6319aae4