### PR TITLE
Fix overlay visibility and match scene startup

### DIFF
--- a/src/scripts/main.js
+++ b/src/scripts/main.js
@@ -118,6 +118,8 @@ class BootScene extends Phaser.Scene {
 
     // Start the overlay scene so match UI elements are ready when needed.
     this.scene.launch('OverlayUI');
+    this.scene.sleep('OverlayUI');
+    this.scene.setVisible('OverlayUI', false);
     this.scene.start('Ranking');
   }
 }

--- a/src/scripts/match-intro-scene.js
+++ b/src/scripts/match-intro-scene.js
@@ -45,8 +45,8 @@ export class MatchIntroScene extends Phaser.Scene {
     const rightTargetX = width * 0.75;
 
     // Position cards just outside the screen based on their explicit width.
-    redCard.setPosition(-redCard.width, cardY).setDepth(5);
-    blueCard.setPosition(width + blueCard.width, cardY).setDepth(5);
+    redCard.setPosition(-redCard.cardWidth, cardY).setDepth(5);
+    blueCard.setPosition(width + blueCard.cardWidth, cardY).setDepth(5);
 
     // --- PRISPENGAR ---
     const purseContainer = this.add.container(width / 2, height * 0.68);
@@ -130,7 +130,7 @@ export class MatchIntroScene extends Phaser.Scene {
       // Rensa animationer och timers så vi inte dubblar
       if (this.tweens && this.tweens.killAll) this.tweens.killAll();
       // Scene key for the actual fight is "Match"
-      this.scene.start('Match', data);
+      this.scene.start('MatchScene', data);
     };
     if (!this._skipHandlersBound) {
       this._skipHandlersBound = true;

--- a/src/scripts/match-scene.js
+++ b/src/scripts/match-scene.js
@@ -19,12 +19,15 @@ import { addMatchLog, getMatchLog } from './match-log.js';
 
 export class MatchScene extends Phaser.Scene {
   constructor() {
-    super('Match');
+    super('MatchScene');
   }
 
   create(data) {
-    console.log('MatchScene: create started');    
+    console.log('MatchScene: create started');
     this.hitLimit = 280; // max distance for a hit to register
+
+    this.scene.wake('OverlayUI');
+    this.scene.setVisible('OverlayUI', true);
 
     const width = this.sys.game.config.width;
     const height = this.sys.game.config.height;

--- a/src/scripts/overlay.js
+++ b/src/scripts/overlay.js
@@ -18,6 +18,7 @@ export class OverlayUI extends Phaser.Scene {
   }
 
   create() {
+    this.scene.setVisible(false);
     const width = this.sys.game.config.width;
     const infoY = 0;
     const infoHeight = 140;
@@ -272,7 +273,9 @@ export class OverlayUI extends Phaser.Scene {
         .setInteractive({ useHandCursor: true })
         .setDepth(1);
       this.newMatchText.on('pointerup', () => {
-        this.scene.stop('Match');
+        this.scene.stop('MatchScene');
+        this.scene.sleep('OverlayUI');
+        this.scene.setVisible('OverlayUI', false);
         this.scene.start('SelectBoxer');
       });
     } else {
@@ -289,7 +292,9 @@ export class OverlayUI extends Phaser.Scene {
         .setInteractive({ useHandCursor: true })
         .setDepth(1);
       this.rankingText.on('pointerup', () => {
-        this.scene.stop('Match');
+        this.scene.stop('MatchScene');
+        this.scene.sleep('OverlayUI');
+        this.scene.setVisible('OverlayUI', false);
         this.scene.start('Ranking');
       });
     } else {
@@ -303,7 +308,9 @@ export class OverlayUI extends Phaser.Scene {
     // post-match buttons fail to appear or when playing on devices
     // without a keyboard.
     const goToRanking = () => {
-      this.scene.stop('Match');
+      this.scene.stop('MatchScene');
+      this.scene.sleep('OverlayUI');
+      this.scene.setVisible('OverlayUI', false);
       this.scene.start('Ranking');
     };
     this.enterHandler = goToRanking;
@@ -337,7 +344,7 @@ export class OverlayUI extends Phaser.Scene {
     }
     this.nextRoundHandler = () => this.triggerNextRound();
     this.input.once('pointerup', this.nextRoundHandler);
-    const match = this.scene.get('Match');
+    const match = this.scene.get('MatchScene');
     if (match?.isP1AI) {
       this.showStrategyOptions();
     }
@@ -362,7 +369,7 @@ export class OverlayUI extends Phaser.Scene {
   }
 
   showStrategyOptions() {
-    const match = this.scene.get('Match');
+    const match = this.scene.get('MatchScene');
     if (!match) return;
     const controller = match.player1?.controller;
     if (!controller || typeof controller.getLevel !== 'function') return;

--- a/src/scripts/round-timer.js
+++ b/src/scripts/round-timer.js
@@ -37,7 +37,7 @@ export class RoundTimer {
     this.remaining = 0;
     eventBus.emit('timer-tick', this.remaining);
     
-    const match = this.scene.scene.get('Match');
+    const match = this.scene.scene.get('MatchScene');
     if (match) {
       const p1 = match.player1;
       const p2 = match.player2;


### PR DESCRIPTION
## Summary
- hide OverlayUI until a match starts and disable it when leaving a match
- correct MatchIntroScene card positions and use MatchScene key
- rename MatchScene key and wake OverlayUI when starting fights

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6899ab6c89a0832a8746b2554eda0894