### PR TITLE
Fix intro stats and coin effect

### DIFF
--- a/src/scripts/main.js
+++ b/src/scripts/main.js
@@ -31,6 +31,7 @@ class BootScene extends Phaser.Scene {
     this.load.audio('whoosh', 'assets/sounds/whoosh.mp3');
     this.load.audio('stinger', 'assets/sounds/whoosh.mp3');
     this.load.audio('coin_jingle', 'assets/sounds/coin-spill.mp3');
+    this.load.image('coin', 'assets/arena/coin.png');
     // Load idle animation frames for the boxers
     for (let i = 0; i < 10; i++) {
       const frame = i.toString().padStart(3, '0');

--- a/src/scripts/match-intro-scene.js
+++ b/src/scripts/match-intro-scene.js
@@ -231,7 +231,19 @@ export class MatchIntroScene extends Phaser.Scene {
 
   // Skapar ett fight card (panel + texter)
   createCard(boxer = {}, weightClass = '', isLeft = true) {
-    const { name = 'Unknown', nick = '', record = { w: 0, l: 0, d: 0 }, rank = 0, country = '' } = boxer;
+    const {
+      name = 'Unknown',
+      nickName = '',
+      nick = '',
+      wins = 0,
+      losses = 0,
+      draws = 0,
+      ranking = 0,
+      country = '',
+      continent = '',
+      age = null,
+    } = boxer;
+    const nickname = nick || nickName || '';
     const c = this.add.container(0, 0);
 
     // Panelbild (preloadad som 'fight_card'). Faller tillbaka till grafik om saknas.
@@ -249,7 +261,9 @@ export class MatchIntroScene extends Phaser.Scene {
     }
     c.add(panel);
 
-    const headline = [name, nick ? `“${nick}”` : ''].filter(Boolean).join(' ');
+    const headline =
+      [name, nickname ? `“${nickname}”` : ''].filter(Boolean).join(' ') +
+      (age ? ` (age ${age})` : '');
     const tName = this.add.text(0, -78, headline, {
       fontFamily: 'Arial',
       fontSize: '30px',
@@ -259,7 +273,7 @@ export class MatchIntroScene extends Phaser.Scene {
     }).setOrigin(0.5);
     c.add(tName);
 
-    const tRecord = this.add.text(0, -20, `Record: ${record.w || 0}-${record.l || 0}-${record.d || 0}`, {
+    const tRecord = this.add.text(0, -20, `Record: ${wins}-${losses}-${draws}`, {
       fontFamily: 'Arial',
       fontSize: '24px',
       color: '#BEE3DB',
@@ -267,7 +281,7 @@ export class MatchIntroScene extends Phaser.Scene {
     }).setOrigin(0.5);
     c.add(tRecord);
 
-    const tRank = this.add.text(0, 20, `Rank: ${rank || 0}`, {
+    const tRank = this.add.text(0, 20, `Rank: ${ranking}`, {
       fontFamily: 'Arial',
       fontSize: '24px',
       color: '#FFD166',
@@ -275,7 +289,14 @@ export class MatchIntroScene extends Phaser.Scene {
     }).setOrigin(0.5);
     c.add(tRank);
 
-    const tClass = this.add.text(0, 64, `${weightClass || ''}${country ? '  •  ' + country : ''}`, {
+    const location = country
+      ? `${country}${continent ? ` (${continent})` : ''}`
+      : '';
+    const tClass = this.add.text(
+      0,
+      64,
+      [weightClass, location].filter(Boolean).join('  •  '),
+      {
       fontFamily: 'Arial',
       fontSize: '22px',
       color: '#FFFFFF',


### PR DESCRIPTION
## Summary
- Show correct record, rank, age and region on intro cards
- Load coin sprite for purse intro coin rain

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6899b0512f8c832a995d37faa0cd27f7