### PR TITLE
Show age on separate line and fix belt and coin visuals

### DIFF
--- a/src/scripts/main.js
+++ b/src/scripts/main.js
@@ -7,6 +7,7 @@ import { CreateBoxerScene } from './create-boxer-scene.js';
 import { MatchLogScene } from './match-log-scene.js';
 import { BackdropManager } from './backdrop-manager.js';
 import { MatchIntroScene } from './match-intro-scene.js';
+import { TITLES } from './title-data.js';
 
 class BootScene extends Phaser.Scene {
   constructor() {
@@ -32,6 +33,9 @@ class BootScene extends Phaser.Scene {
     this.load.audio('stinger', 'assets/sounds/whoosh.mp3');
     this.load.audio('coin_jingle', 'assets/sounds/coin-spill.mp3');
     this.load.image('coin', 'assets/arena/coin.png');
+    TITLES.forEach((t) => {
+      this.load.image(t.name, `assets/titles/${t.name.toLowerCase()}.png`);
+    });
     // Load idle animation frames for the boxers
     for (let i = 0; i < 10; i++) {
       const frame = i.toString().padStart(3, '0');

--- a/src/scripts/match-intro-scene.js
+++ b/src/scripts/match-intro-scene.js
@@ -84,16 +84,17 @@ export class MatchIntroScene extends Phaser.Scene {
     purseContainer.setAlpha(0);
 
     
-    const emitter = this.add.particles(width / 2, height * 0.68, 'coin', {
-      speed: { min: 100, max: 250 },
-      // 270° = uppåt i Phaser (justera ±30° som innan)
-      angle: { min: 240, max: 300 },
-      gravityY: 600,
-      lifespan: 900,
-      quantity: 0,
+    const coins = this.add.particles('coin').setDepth(10);
+    const emitter = coins.createEmitter({
+      x: { min: width / 2 - 250, max: width / 2 + 250 },
+      y: { min: -150, max: -50 },
+      speedY: { min: 200, max: 400 },
+      lifespan: 2000,
+      quantity: 2,
+      frequency: 80,
       scale: { start: 0.7, end: 0.2 },
       alpha: { start: 1, end: 0 },
-      emitting: false
+      on: false
     });
 
     // --- BÄLTEN ---
@@ -186,7 +187,8 @@ export class MatchIntroScene extends Phaser.Scene {
       duration: 280,
       onStart: () => {
         this.sound?.play?.('coin_jingle', { volume: 0.6 });
-        emitter.explode(38, width / 2, height * 0.68);
+        emitter.start();
+        this.time.delayedCall(1200, () => emitter.stop());
         countUp(0, data.purse || 0, 1100, (v) => {
           purseText.setText(formatMoney(v));
         });
@@ -261,10 +263,10 @@ export class MatchIntroScene extends Phaser.Scene {
     }
     c.add(panel);
 
-    const headline =
-      [name, nickname ? `“${nickname}”` : ''].filter(Boolean).join(' ') +
-      (age ? ` (age ${age})` : '');
-    const tName = this.add.text(0, -78, headline, {
+    const headline = [name, nickname ? `“${nickname}”` : '']
+      .filter(Boolean)
+      .join(' ');
+    const tName = this.add.text(0, -90, headline, {
       fontFamily: 'Arial',
       fontSize: '30px',
       color: '#FFFFFF',
@@ -272,6 +274,16 @@ export class MatchIntroScene extends Phaser.Scene {
       wordWrap: { width: 480 }
     }).setOrigin(0.5);
     c.add(tName);
+
+    if (age !== null) {
+      const tAge = this.add.text(0, -52, `Age: ${age}`, {
+        fontFamily: 'Arial',
+        fontSize: '24px',
+        color: '#FFFFFF',
+        align: 'center'
+      }).setOrigin(0.5);
+      c.add(tAge);
+    }
 
     const tRecord = this.add.text(0, -20, `Record: ${wins}-${losses}-${draws}`, {
       fontFamily: 'Arial',


### PR DESCRIPTION
## Summary
- Display age on its own line beneath name and nickname on intro cards
- Add falling coin particle effect when purse is revealed
- Load championship belt images using lower-cased filenames

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6899b34cf6ac832a96ec38050553c41f