### PR TITLE
Add arena info box to match intro scene

### DIFF
--- a/src/scripts/match-intro-scene.js
+++ b/src/scripts/match-intro-scene.js
@@ -40,7 +40,7 @@ export class MatchIntroScene extends Phaser.Scene {
     const redCard = this.createCard(data.red, data.weightClass, true);
     const blueCard = this.createCard(data.blue, data.weightClass, false);
 
-    const cardY = height * 0.35;
+    const cardY = height * 0.3;
     const leftTargetX = width * 0.25;
     const rightTargetX = width * 0.75;
 
@@ -48,8 +48,79 @@ export class MatchIntroScene extends Phaser.Scene {
     redCard.setPosition(-redCard.cardWidth, cardY).setDepth(5);
     blueCard.setPosition(width + blueCard.cardWidth, cardY).setDepth(5);
 
+    // --- ARENAINFO ---
+    const infoContainer = this.add.container(width / 2, height * 0.68);
+    const infoBg = this.add.graphics();
+    infoBg.fillStyle(0x000000, 0.55);
+    infoBg.fillRoundedRect(-300, -60, 600, 120, 14);
+    infoContainer.add(infoBg);
+
+    const locationLine = [
+      data?.arena?.Name,
+      data?.arena?.City,
+      data?.arena?.Country,
+    ]
+      .filter(Boolean)
+      .join(', ');
+
+    // compute or use provided time
+    const computeTime = (prest) => {
+      let start;
+      let end;
+      switch (prest) {
+        case 1:
+          start = 12 * 60;
+          end = 15 * 60;
+          break;
+        case 2:
+          start = 15 * 60 + 30;
+          end = 18 * 60 + 30;
+          break;
+        case 3:
+          start = 19 * 60;
+          end = 23 * 60 + 30;
+          break;
+        default:
+          start = 12 * 60;
+          end = 15 * 60;
+      }
+      const steps = Math.floor((end - start) / 30);
+      const total = start + Phaser.Math.Between(0, steps) * 30;
+      const hour = Math.floor(total / 60)
+        .toString()
+        .padStart(2, '0');
+      const minute = (total % 60).toString().padStart(2, '0');
+      return `${hour}:${minute}`;
+    };
+    const timeDisplay = data.time || computeTime(data?.arena?.Prestige || 1);
+    data.time = timeDisplay;
+
+    const dateLine = [data.date, data.year, timeDisplay].filter(Boolean).join(' ');
+
+    const arenaText = this.add
+      .text(0, -15, locationLine, {
+        fontFamily: 'Arial',
+        fontSize: '26px',
+        color: '#FFFFFF',
+        align: 'center',
+        wordWrap: { width: 560 },
+      })
+      .setOrigin(0.5);
+    infoContainer.add(arenaText);
+
+    const dateText = this.add
+      .text(0, 25, dateLine, {
+        fontFamily: 'Arial',
+        fontSize: '24px',
+        color: '#FFD166',
+        align: 'center',
+      })
+      .setOrigin(0.5);
+    infoContainer.add(dateText);
+    infoContainer.setAlpha(0);
+
     // --- PRISPENGAR ---
-    const purseContainer = this.add.container(width / 2, height * 0.68);
+    const purseContainer = this.add.container(width / 2, height * 0.85);
     const purseBg = this.add.graphics();
     purseBg.fillStyle(0x000000, 0.55);
     purseBg.fillRoundedRect(-300, -80, 600, 160, 14);
@@ -179,7 +250,14 @@ export class MatchIntroScene extends Phaser.Scene {
     // 2) Paus
     steps.push({ type: 'delay', ms: 450 });
 
-    // 3) Purse + counter + coins
+    // 3) Arena info
+    steps.push({
+      targets: infoContainer,
+      alpha: 1,
+      duration: 280,
+    });
+
+    // 4) Purse + counter + coins
     steps.push({
       targets: purseContainer,
       alpha: 1,
@@ -197,7 +275,7 @@ export class MatchIntroScene extends Phaser.Scene {
       }
     });
 
-    // 4) Bälten en och en + shine
+    // 5) Bälten en och en + shine
     belts.forEach((belt) => {
       steps.push({
         targets: belt,
@@ -210,7 +288,7 @@ export class MatchIntroScene extends Phaser.Scene {
       });
     });
 
-    // 5) CTA + blink
+    // 6) CTA + blink
     steps.push({
       targets: cta,
       alpha: 1,

--- a/src/scripts/match-scene.js
+++ b/src/scripts/match-scene.js
@@ -132,46 +132,47 @@ export class MatchScene extends Phaser.Scene {
         const [day, month] = ds.split(' ');
         dateStr = `${day} ${month.charAt(0).toUpperCase()}${month.slice(1)}`;
       }
-      const prestige = data?.arena?.Prestige || 1;
-      const getTime = (prest) => {
-        let start;
-        let end;
-        switch (prest) {
-          case 1:
-            start = 12 * 60;
-            end = 15 * 60;
-            break;
-          case 2:
-            start = 15 * 60 + 30;
-            end = 18 * 60 + 30;
-            break;
-          case 3:
-            start = 19 * 60;
-            end = 23 * 60 + 30;
-            break;
-          default:
-            start = 12 * 60;
-            end = 15 * 60;
-        }
-        const steps = Math.floor((end - start) / 30);
-        const total = start + Phaser.Math.Between(0, steps) * 30;
-        return { hour: Math.floor(total / 60), minute: total % 60 };
-      };
-      const { hour, minute } = getTime(prestige);
-      const timeDisplay = `${hour.toString().padStart(2, '0')}:${minute
-        .toString()
-        .padStart(2, '0')}`;
-      this.matchMeta = {
-        year,
-        date: dateStr,
-        rank: user.ranking,
-        opponentRank: opponent.ranking,
-        arena: data?.arena,
-      };
-      eventBus.emit('match-date', {
-        date: dateStr,
-        year,
-        time: timeDisplay,
+        const prestige = data?.arena?.Prestige || 1;
+        const computeTime = (prest) => {
+          let start;
+          let end;
+          switch (prest) {
+            case 1:
+              start = 12 * 60;
+              end = 15 * 60;
+              break;
+            case 2:
+              start = 15 * 60 + 30;
+              end = 18 * 60 + 30;
+              break;
+            case 3:
+              start = 19 * 60;
+              end = 23 * 60 + 30;
+              break;
+            default:
+              start = 12 * 60;
+              end = 15 * 60;
+          }
+          const steps = Math.floor((end - start) / 30);
+          const total = start + Phaser.Math.Between(0, steps) * 30;
+          const hour = Math.floor(total / 60)
+            .toString()
+            .padStart(2, '0');
+          const minute = (total % 60).toString().padStart(2, '0');
+          return `${hour}:${minute}`;
+        };
+        const timeDisplay = data?.time || computeTime(prestige);
+        this.matchMeta = {
+          year,
+          date: dateStr,
+          rank: user.ranking,
+          opponentRank: opponent.ranking,
+          arena: data?.arena,
+        };
+        eventBus.emit('match-date', {
+          date: dateStr,
+          year,
+          time: timeDisplay,
         arena: data?.arena?.Name || '',
         city: data?.arena?.City || '',
         country: data?.arena?.Country || '',

--- a/src/scripts/next-match.js
+++ b/src/scripts/next-match.js
@@ -19,10 +19,38 @@ function computeDate() {
   return { year, date: formattedDate };
 }
 
+function computeTime(prestige = 1) {
+  let start;
+  let end;
+  switch (prestige) {
+    case 1:
+      start = 12 * 60;
+      end = 15 * 60;
+      break;
+    case 2:
+      start = 15 * 60 + 30;
+      end = 18 * 60 + 30;
+      break;
+    case 3:
+      start = 19 * 60;
+      end = 23 * 60 + 30;
+      break;
+    default:
+      start = 12 * 60;
+      end = 15 * 60;
+  }
+  const steps = Math.floor((end - start) / 30);
+  const total = start + Math.floor(Math.random() * (steps + 1)) * 30;
+  const hour = String(Math.floor(total / 60)).padStart(2, '0');
+  const minute = String(total % 60).padStart(2, '0');
+  return `${hour}:${minute}`;
+}
+
 export function scheduleMatch({ boxer1, boxer2, aiLevel1, aiLevel2, rounds }) {
   const highestRank = Math.min(boxer1.ranking, boxer2.ranking);
   const arena = ArenaManager.getRandomArena(highestRank);
   const { year, date } = computeDate();
+  const time = computeTime(arena?.Prestige || 1);
   const { purse, winnerBonus, titlesOnTheLine } = getMatchPreview(
     boxer1,
     boxer2
@@ -36,6 +64,7 @@ export function scheduleMatch({ boxer1, boxer2, aiLevel1, aiLevel2, rounds }) {
     arena,
     year,
     date,
+    time,
     purse,
     winnerBonus,
     titlesOnTheLine,


### PR DESCRIPTION
## Summary
- Show arena location and match date/time during intro
- Push fighter cards up and purse down to fit new info box
- Propagate scheduled fight time across scenes

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6899bf9266ac832aaa4b34b43ce622f8