### PR TITLE
feat: show boxer match logs from rankings

### DIFF
--- a/src/scripts/match-log-scene.js
+++ b/src/scripts/match-log-scene.js
@@ -9,13 +9,13 @@ export class MatchLogScene extends Phaser.Scene {
     super('MatchLog');
   }
 
-  create() {
+  create(data) {
     const width = this.sys.game.config.width;
     SoundManager.playMenuLoop();
-    const player = getPlayerBoxer();
-    const header = player
-      ? `${player.name} (${player.wins || 0} Win ${player.losses || 0} Loss ${
-          player.winsByKO || 0
+    const boxer = data?.boxer || getPlayerBoxer();
+    const header = boxer
+      ? `${boxer.name} (${boxer.wins || 0} Win ${boxer.losses || 0} Loss ${
+          boxer.winsByKO || 0
         } KO)`
       : 'Match log';
     this.add
@@ -25,7 +25,7 @@ export class MatchLogScene extends Phaser.Scene {
       })
       .setOrigin(0.5, 0);
 
-    this.log = getMatchLog();
+    this.log = getMatchLog(boxer?.name);
     this.expandedRows = new Set();
     const tableWidth = width * 0.95;
     const startX = width * 0.025;

--- a/src/scripts/match-log.js
+++ b/src/scripts/match-log.js
@@ -1,17 +1,31 @@
-let matchLog = [];
+let matchLog = {};
 
-export function addMatchLog(entry) {
-  matchLog.push(entry);
+export function addMatchLog(boxer, entry) {
+  if (!matchLog[boxer]) {
+    matchLog[boxer] = [];
+  }
+  matchLog[boxer].push(entry);
 }
 
-export function getMatchLog() {
+export function getMatchLog(boxer) {
+  if (boxer) {
+    return matchLog[boxer] || [];
+  }
+  return Object.values(matchLog).flat();
+}
+
+export function getAllMatchLogs() {
   return matchLog;
 }
 
-export function setMatchLog(log = []) {
-  matchLog = Array.isArray(log) ? log : [];
+export function setMatchLog(log = {}) {
+  if (log && typeof log === 'object' && !Array.isArray(log)) {
+    matchLog = log;
+  } else {
+    matchLog = {};
+  }
 }
 
 export function resetMatchLog() {
-  matchLog = [];
+  matchLog = {};
 }

--- a/src/scripts/ranking-scene.js
+++ b/src/scripts/ranking-scene.js
@@ -97,7 +97,11 @@ export class RankingScene extends Phaser.Scene {
       const y = startY + i * rowHeight;
       const rowRect = this.add
         .rectangle(width / 2, y, rectWidth, rowHeight, 0x808080, tableAlpha)
-        .setOrigin(0.5, 0);
+        .setOrigin(0.5, 0)
+        .setInteractive({ useHandCursor: true })
+        .on('pointerup', () => {
+          this.scene.start('MatchLog', { boxer: b });
+        });
       const line =
         `${b.ranking.toString().padEnd(columnWidths[0])}` +
         `${b.name.padEnd(columnWidths[1])}` +
@@ -116,7 +120,11 @@ export class RankingScene extends Phaser.Scene {
           color: isPlayer ? '#0000ff' : '#ffffff',
           fontStyle: isPlayer ? 'bold' : 'normal',
         })
-        .setOrigin(0, 0);
+        .setOrigin(0, 0)
+        .setInteractive({ useHandCursor: true })
+        .on('pointerup', () => {
+          this.scene.start('MatchLog', { boxer: b });
+        });
 
       content.add(rowRect);
       content.add(txt);
@@ -299,17 +307,6 @@ export class RankingScene extends Phaser.Scene {
           });
         nextY = resetBtn.y + 40;
       }
-
-      this.add
-        .text(tableLeft, nextY, 'Match log', {
-          font: '20px Arial',
-          color: '#ffffff',
-        })
-        .setOrigin(0, 0)
-        .setInteractive({ useHandCursor: true })
-        .on('pointerup', () => {
-          this.scene.start('MatchLog');
-        });
     }
   }
 }

--- a/src/scripts/save-system.js
+++ b/src/scripts/save-system.js
@@ -1,6 +1,6 @@
 import { BOXERS, resetBoxers, addBoxer } from './boxers.js';
 import { setPlayerBoxer } from './player-boxer.js';
-import { getMatchLog, setMatchLog, resetMatchLog } from './match-log.js';
+import { setMatchLog, resetMatchLog, getAllMatchLogs } from './match-log.js';
 
 const SAVE_KEY = 'theBoxer.save.v1';
 const VERSION = 1;
@@ -59,7 +59,7 @@ export function saveGameState(boxers) {
         }
         return base;
       }),
-      matchLog: getMatchLog(),
+      matchLog: getAllMatchLogs(),
     };
     localStorage.setItem(SAVE_KEY, JSON.stringify(payload));
   } catch (err) {
@@ -71,7 +71,7 @@ export function saveGameState(boxers) {
 export function applyLoadedState(state) {
   if (!state || !Array.isArray(state.boxers)) return;
   setPlayerBoxer(null);
-  setMatchLog(state.matchLog || []);
+  setMatchLog(state.matchLog || {});
   state.boxers.forEach((saved) => {
     let boxer = BOXERS.find((b) => b.name === saved.id);
     if (!boxer && saved.userCreated) {


### PR DESCRIPTION
## Summary
- store match logs per boxer and persist them
- open a boxer's log by clicking their row in rankings
- record match results for both fighters and view per-boxer history

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node --check src/scripts/match-log.js`
- `node --check src/scripts/save-system.js`
- `node --check src/scripts/match-scene.js`
- `node --check src/scripts/match-log-scene.js`
- `node --check src/scripts/ranking-scene.js`


------
https://chatgpt.com/codex/tasks/task_e_6899d66e1924832ab6650518bc61444d