### PR TITLE
feat: animate next fight button

### DIFF
--- a/src/scripts/main.js
+++ b/src/scripts/main.js
@@ -33,6 +33,11 @@ class BootScene extends Phaser.Scene {
     this.load.audio('stinger', 'assets/sounds/whoosh.mp3');
     this.load.audio('coin_jingle', 'assets/sounds/coin-spill.mp3');
     this.load.image('coin', 'assets/arena/coin.png');
+    this.load.image('fight_card', 'assets/arena/fight-card.png');
+    this.load.image(
+      'glove_horizontal',
+      'assets/arena/glove-horisontal.png'
+    );
     TITLES.forEach((t) => {
       this.load.image(t.name, `assets/titles/${t.name.toLowerCase()}.png`);
     });

--- a/src/scripts/ranking-scene.js
+++ b/src/scripts/ranking-scene.js
@@ -263,30 +263,68 @@ export class RankingScene extends Phaser.Scene {
           this.scene.start('MatchIntroScene', matchData);
         });
     } else {
-      const btnLabel = getTestMode()
-        ? 'Start new game'
-        : hasPlayer
-        ? 'Setup next fight'
-        : 'Start new game';
-      const startBtn = this.add
-        .text(tableLeft, tableBottom + 10, btnLabel, {
-          font: '24px Arial',
-          color: '#00ff00',
-        })
-        .setOrigin(0, 0)
-        .setInteractive({ useHandCursor: true })
-        .on('pointerup', () => {
-          if (getTestMode()) {
-            this.scene.start('SelectBoxer');
-          } else if (hasPlayer) {
-            this.scene.start('SelectBoxer');
-          } else {
-            this.scene.start('CreateBoxer');
-          }
+      let startBtn;
+      let nextY;
+      if (hasPlayer && !getTestMode()) {
+        const btnX = tableLeft + 250;
+        const btnY = tableBottom + 50;
+        startBtn = this.add.container(btnX, btnY);
+        startBtn.setSize(500, 80);
+        const bg = this.add
+          .image(0, 0, 'fight_card')
+          .setDisplaySize(500, 80);
+        const label = this.add
+          .text(0, 0, 'Next fight', {
+            font: '32px Arial',
+            color: '#ffffff',
+          })
+          .setOrigin(0.5);
+        const gloveL = this.add
+          .image(-300, 0, 'glove_horizontal')
+          .setDisplaySize(100, 70);
+        const gloveR = this.add
+          .image(300, 0, 'glove_horizontal')
+          .setDisplaySize(100, 70)
+          .setFlipX(true);
+        startBtn.add([bg, label, gloveL, gloveR]);
+        this.tweens.add({
+          targets: gloveL,
+          x: -150,
+          duration: 800,
+          ease: 'Sine.Out',
         });
+        this.tweens.add({
+          targets: gloveR,
+          x: 150,
+          duration: 800,
+          ease: 'Sine.Out',
+        });
+        startBtn
+          .setInteractive({ useHandCursor: true })
+          .on('pointerup', () => {
+            this.scene.start('SelectBoxer');
+          });
+        nextY = btnY + 60;
+      } else {
+        const btnLabel = 'Start new game';
+        startBtn = this.add
+          .text(tableLeft, tableBottom + 10, btnLabel, {
+            font: '24px Arial',
+            color: '#00ff00',
+          })
+          .setOrigin(0, 0)
+          .setInteractive({ useHandCursor: true })
+          .on('pointerup', () => {
+            if (getTestMode()) {
+              this.scene.start('SelectBoxer');
+            } else {
+              this.scene.start('CreateBoxer');
+            }
+          });
+        nextY = startBtn.y + 40;
+      }
 
       // Optional reset button and match log link
-      let nextY = startBtn.y + 40;
       if (getTestMode()) {
         const resetBtn = this.add
           .text(tableLeft, nextY, 'Reset data', {


### PR DESCRIPTION
## Summary
- preload fight card and glove assets in BootScene
- redesign next fight button with fight card background and animated gloves

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6899d91299dc832abde3b6dae169ef84