### PR TITLE
Use ranking list color for tables and fix match intro card

### DIFF
--- a/src/scripts/match-intro-scene.js
+++ b/src/scripts/match-intro-scene.js
@@ -336,17 +336,20 @@ export class MatchIntroScene extends Phaser.Scene {
     const nickname = nick || nickName || '';
     const c = this.add.container(0, 0);
 
+    const cardWidth = 520;
+    const cardHeight = 310;
+
     // Panelbild (preloadad som 'fight_card'). Faller tillbaka till grafik om saknas.
     let panel;
     if (this.textures.exists('fight_card')) {
       panel = this.add.image(0, 0, 'fight_card').setOrigin(0.5);
-      panel.setDisplaySize(520, 300);
+      panel.setDisplaySize(cardWidth, cardHeight);
     } else {
       const g = this.add.graphics();
       g.fillStyle(0x0b0b0f, 0.85);
-      g.fillRoundedRect(-260, -150, 520, 300, 12);
+      g.fillRoundedRect(-cardWidth / 2, -cardHeight / 2, cardWidth, cardHeight, 12);
       g.lineStyle(2, 0xC1A44A, 0.9);
-      g.strokeRoundedRect(-260, -150, 520, 300, 12);
+      g.strokeRoundedRect(-cardWidth / 2, -cardHeight / 2, cardWidth, cardHeight, 12);
       panel = g;
     }
     c.add(panel);
@@ -354,7 +357,7 @@ export class MatchIntroScene extends Phaser.Scene {
     const headline = [name, nickname ? `“${nickname}”` : '']
       .filter(Boolean)
       .join(' ');
-    const tName = this.add.text(0, -90, headline, {
+    const tName = this.add.text(0, -80, headline, {
       fontFamily: 'Arial',
       fontSize: '30px',
       color: '#FFFFFF',
@@ -364,7 +367,7 @@ export class MatchIntroScene extends Phaser.Scene {
     c.add(tName);
 
     if (age !== null) {
-      const tAge = this.add.text(0, -52, `Age: ${age}`, {
+      const tAge = this.add.text(0, -42, `Age: ${age}`, {
         fontFamily: 'Arial',
         fontSize: '24px',
         color: '#FFFFFF',
@@ -373,7 +376,7 @@ export class MatchIntroScene extends Phaser.Scene {
       c.add(tAge);
     }
 
-    const tRecord = this.add.text(0, -20, `Record: ${wins}-${losses}-${draws}`, {
+    const tRecord = this.add.text(0, -10, `Record: ${wins}-${losses}-${draws}`, {
       fontFamily: 'Arial',
       fontSize: '24px',
       color: '#BEE3DB',
@@ -381,7 +384,7 @@ export class MatchIntroScene extends Phaser.Scene {
     }).setOrigin(0.5);
     c.add(tRecord);
 
-    const tRank = this.add.text(0, 20, `Rank: ${ranking}`, {
+    const tRank = this.add.text(0, 30, `Rank: ${ranking}`, {
       fontFamily: 'Arial',
       fontSize: '24px',
       color: '#FFD166',
@@ -394,7 +397,7 @@ export class MatchIntroScene extends Phaser.Scene {
       : '';
     const tClass = this.add.text(
       0,
-      64,
+      74,
       [weightClass, location].filter(Boolean).join('  •  '),
       {
       fontFamily: 'Arial',
@@ -412,8 +415,6 @@ export class MatchIntroScene extends Phaser.Scene {
     }
 
     // Hjälp-egenskaper: sätt storlek utan att påverka skalning
-    const cardWidth = 520;
-    const cardHeight = 300;
     c.setSize(cardWidth, cardHeight);
     c.cardWidth = cardWidth;
     c.cardHeight = cardHeight;

--- a/src/scripts/match-log-scene.js
+++ b/src/scripts/match-log-scene.js
@@ -53,7 +53,7 @@ export class MatchLogScene extends Phaser.Scene {
     });
     const headerY = 80;
     this.add
-      .rectangle(width / 2, headerY, tableWidth, rowHeight, 0x808080, tableAlpha)
+      .rectangle(width / 2, headerY, tableWidth, rowHeight, 0x001b44, tableAlpha)
       .setOrigin(0.5, 0);
     if (!this.log.length) {
       this.add
@@ -106,7 +106,7 @@ export class MatchLogScene extends Phaser.Scene {
     const rowHeight = this.rowHeight;
     this.log.forEach((entry, index) => {
       const rowRect = this.add
-        .rectangle(width / 2, y, this.tableWidth, rowHeight, 0x808080, tableAlpha)
+        .rectangle(width / 2, y, this.tableWidth, rowHeight, 0x001b44, tableAlpha)
         .setOrigin(0.5, 0);
       this.rowObjs.push(rowRect);
 

--- a/src/scripts/select-boxer-scene.js
+++ b/src/scripts/select-boxer-scene.js
@@ -74,7 +74,7 @@ export class SelectBoxerScene extends Phaser.Scene {
     const rowHeight = 24;
     this.options.push(
       this.add
-        .rectangle(width / 2, 60, rectWidth, rowHeight, 0x808080, tableAlpha)
+        .rectangle(width / 2, 60, rectWidth, rowHeight, 0x001b44, tableAlpha)
         .setOrigin(0.5, 0)
     );
     const headers =
@@ -95,7 +95,7 @@ export class SelectBoxerScene extends Phaser.Scene {
       const y = 80 + i * 24;
       this.options.push(
         this.add
-          .rectangle(width / 2, y, rectWidth, rowHeight, 0x808080, tableAlpha)
+          .rectangle(width / 2, y, rectWidth, rowHeight, 0x001b44, tableAlpha)
           .setOrigin(0.5, 0)
       );
       const line =
@@ -173,7 +173,7 @@ export class SelectBoxerScene extends Phaser.Scene {
     const tableLeft = (width - rectWidth) / 2;
     this.options.push(
       this.add
-        .rectangle(width / 2, 60, rectWidth, rowHeight, 0x808080, tableAlpha)
+        .rectangle(width / 2, 60, rectWidth, rowHeight, 0x001b44, tableAlpha)
         .setOrigin(0.5, 0)
     );
     const headers = `${'Rank'.padEnd(columnWidths[0])}${'Name'.padEnd(columnWidths[1])}${'Age'.padEnd(columnWidths[2])}${'M'.padEnd(columnWidths[3])}${'W'.padEnd(columnWidths[4])}${'L'.padEnd(columnWidths[5])}${'D'.padEnd(columnWidths[6])}${'KO'.padEnd(columnWidths[7])}`;
@@ -196,7 +196,7 @@ export class SelectBoxerScene extends Phaser.Scene {
       const y = 80 + i * 24;
       this.options.push(
         this.add
-          .rectangle(width / 2, y, rectWidth, rowHeight, 0x808080, tableAlpha)
+          .rectangle(width / 2, y, rectWidth, rowHeight, 0x001b44, tableAlpha)
           .setOrigin(0.5, 0)
       );
       const line = `${b.ranking.toString().padEnd(columnWidths[0])}${b.name.padEnd(columnWidths[1])}${b.age.toString().padEnd(columnWidths[2])}${b.matches.toString().padEnd(columnWidths[3])}${b.wins.toString().padEnd(columnWidths[4])}${b.losses.toString().padEnd(columnWidths[5])}${b.draws.toString().padEnd(columnWidths[6])}${b.winsByKO.toString().padEnd(columnWidths[7])}`;


### PR DESCRIPTION
## Summary
- Match opponent and match log tables to ranking list's dark theme
- Correct right-side fight card size and add top text padding

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6899e8973364832abeee4a43704802f8