### PR TITLE
Fix scaling of right boxer card in match intro scene

### DIFF
--- a/src/scripts/match-intro-scene.js
+++ b/src/scripts/match-intro-scene.js
@@ -408,11 +408,9 @@ export class MatchIntroScene extends Phaser.Scene {
     c.add(tClass);
 
     // Spegla lite om högerkort för variation (valfritt)
-    if (!isLeft) {
-      c.list.forEach((child) => {
-        if (child.setScale) child.setScale(1.0);
-      });
-    }
+    // Tidigare skalades högerkortets innehåll om vilket gjorde kortet
+    // oproportionerligt stort. Vi låter alla element behålla sina
+    // ursprungliga skalor så att både vänster och höger kort ser likadana ut.
 
     // Hjälp-egenskaper: sätt storlek utan att påverka skalning
     c.setSize(cardWidth, cardHeight);


### PR DESCRIPTION
## Summary
- Prevent right-side boxer card from rescaling to massive size in MatchIntroScene by preserving element scales

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6899eab43790832a9aa6ec3eca8046a3