### PR TITLE
Add control buttons with icons and store boxer region

### DIFF
--- a/src/scripts/main.js
+++ b/src/scripts/main.js
@@ -38,6 +38,8 @@ class BootScene extends Phaser.Scene {
       'glove_horizontal',
       'assets/arena/glove-horisontal.png'
     );
+    this.load.image('keyboard', 'assets/arena/keyboard.png');
+    this.load.image('computer', 'assets/arena/computer.png');
     TITLES.forEach((t) => {
       this.load.image(t.name, `assets/titles/${t.name.toLowerCase()}.png`);
     });

--- a/src/scripts/save-system.js
+++ b/src/scripts/save-system.js
@@ -47,6 +47,7 @@ export function saveGameState(boxers) {
             userCreated: true,
             nickName: b.nickName,
             country: b.country,
+            continent: b.continent,
             age: b.age,
             stamina: b.stamina,
             power: b.power,
@@ -79,6 +80,7 @@ export function applyLoadedState(state) {
         name: saved.id,
         nickName: saved.nickName || '',
         country: saved.country || '',
+        continent: saved.continent || '',
         age: saved.age || 18,
         stamina: saved.stamina ?? 1,
         power: saved.power ?? 1,
@@ -115,6 +117,7 @@ export function applyLoadedState(state) {
       boxer.userCreated = true;
       boxer.nickName = saved.nickName ?? boxer.nickName;
       boxer.country = saved.country ?? boxer.country;
+      boxer.continent = saved.continent ?? boxer.continent;
       boxer.age = saved.age ?? boxer.age;
       boxer.stamina = saved.stamina ?? boxer.stamina;
       boxer.power = saved.power ?? boxer.power;

--- a/src/scripts/select-boxer-scene.js
+++ b/src/scripts/select-boxer-scene.js
@@ -142,21 +142,21 @@ export class SelectBoxerScene extends Phaser.Scene {
   showControlOptions() {
     this.clearOptions();
     const width = this.sys.game.config.width;
-    const keyboard = this.add.text(width / 2, 60, 'Keyboard', {
-      font: '20px Arial',
-      color: '#ffffff',
-    });
-    keyboard.setOrigin(0.5, 0);
-    keyboard.setInteractive({ useHandCursor: true });
-    keyboard.on('pointerdown', () => this.selectControl('human'));
-    const ai = this.add.text(width / 2, 100, 'AI', {
-      font: '20px Arial',
-      color: '#ffffff',
-    });
-    ai.setOrigin(0.5, 0);
-    ai.setInteractive({ useHandCursor: true });
-    ai.on('pointerdown', () => this.selectControl('ai'));
-    this.options.push(keyboard, ai);
+    const makeOption = (y, label, icon, handler) => {
+      const container = this.add.container(width / 2, y);
+      const bg = this.add.rectangle(0, 0, 200, 40, 0x001b44, 0.4);
+      const img = this.add.image(-60, 0, icon).setDisplaySize(32, 32);
+      const txt = this.add
+        .text(-40, 0, label, { font: '20px Arial', color: '#ffffff' })
+        .setOrigin(0, 0.5);
+      container.add([bg, img, txt]);
+      container.setSize(200, 40);
+      container.setInteractive({ useHandCursor: true });
+      container.on('pointerdown', handler);
+      this.options.push(container);
+    };
+    makeOption(80, 'Keyboard', 'keyboard', () => this.selectControl('human'));
+    makeOption(130, 'Computer', 'computer', () => this.selectControl('ai'));
   }
 
   showOpponentOptions() {


### PR DESCRIPTION
## Summary
- Preload keyboard and computer icons for control selection
- Use interactive control buttons with icons in boxer selection
- Persist boxer region (continent) in saved game data
- Remove placeholder keyboard/computer image files

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6899ed7d3560832a8e519cad3f39b7b5