### PR TITLE
Fix strategy selection and add max level parameter

### DIFF
--- a/src/scripts/overlay.js
+++ b/src/scripts/overlay.js
@@ -321,7 +321,7 @@ export class OverlayUI extends Phaser.Scene {
     this.input.once('pointerup', this.nextRoundHandler);
     const match = this.scene.get('MatchScene');
     if (match?.isP1AI) {
-      this.showStrategyOptions();
+      this.showStrategyOptions(10);
     }
   }
 
@@ -343,7 +343,7 @@ export class OverlayUI extends Phaser.Scene {
     this.hideStrategyOptions();
   }
 
-  showStrategyOptions() {
+  showStrategyOptions(maxLevel = 10) {
     const match = this.scene.get('MatchScene');
     if (!match) return;
     const controller = match.player1?.controller;
@@ -358,7 +358,7 @@ export class OverlayUI extends Phaser.Scene {
     const slider = this.add.dom(width / 2, height / 2, 'input', {
       type: 'range',
       min: '1',
-      max: '10',
+      max: String(maxLevel),
       value: String(current),
       style: 'width:300px',
     });

--- a/src/scripts/select-boxer-scene.js
+++ b/src/scripts/select-boxer-scene.js
@@ -274,7 +274,7 @@ export class SelectBoxerScene extends Phaser.Scene {
     } else {
       this.step = 1;
       this.instruction.setText('Choose Player 1 strategy');
-      this.showStrategyOptions();
+      this.showStrategyOptions(10);
     }
   }
 
@@ -308,7 +308,7 @@ export class SelectBoxerScene extends Phaser.Scene {
         if (getTestMode()) {
           this.step = 2;
           this.instruction.setText('Choose Player 1 strategy');
-          this.showStrategyOptions();
+          this.showStrategyOptions(10);
         } else {
           this.selectedStrategy1 = 'default';
           this.step = 2;
@@ -320,7 +320,7 @@ export class SelectBoxerScene extends Phaser.Scene {
       if (getTestMode()) {
         this.step = 4;
         this.instruction.setText("Choose the opponent's strategy");
-        this.showStrategyOptions();
+        this.showStrategyOptions(10);
       } else {
         this.selectedStrategy2 = 'default';
         this.step = 5;
@@ -335,27 +335,21 @@ export class SelectBoxerScene extends Phaser.Scene {
     if (this.step === 1) {
       // non-test mode: player strategy selection
       this.selectedStrategy1 = level;
-      this.input.once('pointerup', () => {
-        this.step = 2;
-        this.instruction.setText('Choose your opponent');
-        this.showOpponentOptions();
-      });
+      this.step = 2;
+      this.instruction.setText('Choose your opponent');
+      this.showOpponentOptions();
     } else if (this.step === 2) {
       // test mode: player strategy selection
       this.selectedStrategy1 = level;
-      this.input.once('pointerup', () => {
-        this.step = 3;
-        this.instruction.setText('Choose your opponent');
-        this.showBoxerOptions();
-      });
+      this.step = 3;
+      this.instruction.setText('Choose your opponent');
+      this.showBoxerOptions();
     } else if (this.step === 4) {
       // test mode: opponent strategy selection
       this.selectedStrategy2 = level;
-      this.input.once('pointerup', () => {
-        this.step = 5;
-        this.instruction.setText('Choose number of rounds (1-13)');
-        this.showRoundOptions();
-      });
+      this.step = 5;
+      this.instruction.setText('Choose number of rounds (1-13)');
+      this.showRoundOptions();
     }
   }
 


### PR DESCRIPTION
## Summary
- Apply chosen strategy to boxer immediately after selection
- Allow strategy UI to accept a configurable max level (default 10)

## Testing
- `npm test` *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_689a154fa76c832a8399ea66815f34ee