### PR TITLE
Format KO times in match log as mm:ss

### DIFF
--- a/src/scripts/match-log-scene.js
+++ b/src/scripts/match-log-scene.js
@@ -165,8 +165,7 @@ export class MatchLogScene extends Phaser.Scene {
       };
       const monthNum = months[monthName] || '01';
       const dateStr = `${entry.year}${monthNum}${String(day).padStart(2, '0')}`;
-      const timeStr =
-        entry.method === 'KO' ? String(entry.time).padStart(5, '0') : '-';
+      const timeStr = entry.method === 'KO' ? String(entry.time) : '-';
       const row = [
         dateStr,
         arenaText,

--- a/src/scripts/match-scene.js
+++ b/src/scripts/match-scene.js
@@ -436,7 +436,7 @@ export class MatchScene extends Phaser.Scene {
     const timeSec = this.roundLength - this.roundTimer.remaining;
     const minutes = Math.floor(timeSec / 60);
     const seconds = Math.floor(timeSec % 60);
-    const timeStr = `${minutes} min ${seconds} sec.`;
+    const timeStr = `${minutes}:${seconds.toString().padStart(2, '0')}`;
     const b1 = this.player1.stats;
     const b2 = this.player2.stats;
     const rank1 = b1.ranking;


### PR DESCRIPTION
## Summary
- display KO time as mm:ss when recording match results
- remove zero-padding for minutes when rendering match log

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689a17a93a70832aaa19378acd5a93da