### PR TITLE
Start scene routing and simplified career hub

### DIFF
--- a/src/scripts/main.js
+++ b/src/scripts/main.js
@@ -5,6 +5,8 @@ import { RankingScene } from './ranking-scene.js';
 import { SoundManager } from './sound-manager.js';
 import { CreateBoxerScene } from './create-boxer-scene.js';
 import { MatchLogScene } from './match-log-scene.js';
+import { StartScene } from './start-scene.js';
+import { OptionsScene } from './options-scene.js';
 import { BackdropManager } from './backdrop-manager.js';
 import { MatchIntroScene } from './match-intro-scene.js';
 import { TITLES } from './title-data.js';
@@ -114,7 +116,7 @@ class BootScene extends Phaser.Scene {
   }
 
   create() {
-    console.log('BootScene: preload complete, switching to Ranking');
+    console.log('BootScene: preload complete, switching to StartScene');
     SoundManager.init(this);
     BackdropManager.init();
 
@@ -132,7 +134,7 @@ class BootScene extends Phaser.Scene {
     this.scene.launch('OverlayUI');
     this.scene.sleep('OverlayUI');
     this.scene.setVisible('OverlayUI', false);
-    this.scene.start('Ranking');
+    this.scene.start('StartScene');
   }
 }
 
@@ -146,9 +148,11 @@ const config = {
   transparent: true,
   scene: [
     BootScene,
+    StartScene,
     RankingScene,
     MatchLogScene,
     CreateBoxerScene,
+    OptionsScene,
     SelectBoxerScene,
     MatchIntroScene,
     MatchScene,

--- a/src/scripts/ranking-scene.js
+++ b/src/scripts/ranking-scene.js
@@ -1,5 +1,5 @@
 import { getRankings } from './boxer-stats.js';
-import { appConfig, getTestMode } from './config.js';
+import { appConfig } from './config.js';
 import { getPlayerBoxer } from './player-boxer.js';
 import { formatMoney } from './helpers.js';
 import { SoundManager } from './sound-manager.js';
@@ -8,7 +8,6 @@ import {
   loadGameState,
   applyLoadedState,
   migrateIfNeeded,
-  resetSavedData,
 } from './save-system.js';
 
 export class RankingScene extends Phaser.Scene {
@@ -218,7 +217,6 @@ export class RankingScene extends Phaser.Scene {
     const tableBottom = viewportY + viewportHeight;
 
     const pending = getPendingMatch();
-    const hasPlayer = !!getPlayerBoxer();
     if (pending) {
       const infoY = tableBottom + 10;
       this.add.text(
@@ -265,87 +263,45 @@ export class RankingScene extends Phaser.Scene {
           this.scene.start('MatchIntroScene', matchData);
         });
     } else {
-      let startBtn;
-      let nextY;
-      if (hasPlayer && !getTestMode()) {
-        const btnX = width / 2;
-        const btnY = tableBottom + 50;
-        startBtn = this.add.container(btnX, btnY);
-        startBtn.setSize(500, 80);
-        const bg = this.add
-          .rectangle(0, 0, 500, 80, bgColor, bgAlpha);
-        const label = this.add
-          .text(0, 0, 'Next fight', {
-            font: '32px Arial',
-            color: '#ffffff',
-          })
-          .setOrigin(0.5);
-        const gloveL = this.add
-          .image(-300, 0, 'glove_horizontal')
-          .setDisplaySize(100, 70);
-        const gloveR = this.add
-          .image(300, 0, 'glove_horizontal')
-          .setDisplaySize(100, 70)
-          .setFlipX(true);
-        startBtn.add([bg, label, gloveL, gloveR]);
-        this.tweens.add({
-          targets: gloveL,
-          x: -150,
-          duration: 800,
-          ease: 'Sine.Out',
-        });
-        this.tweens.add({
-          targets: gloveR,
-          x: 150,
-          duration: 800,
-          ease: 'Sine.Out',
-        });
-        startBtn
-          .setInteractive({ useHandCursor: true })
-          .on('pointerup', () => {
-            this.scene.start('SelectBoxer');
-          });
-        nextY = btnY + 60;
-      } else {
-        const btnLabel = 'Start new game';
-        startBtn = this.add
-          .text(tableLeft, tableBottom + 10, btnLabel, {
-            font: '24px Arial',
-            color: '#00ff00',
-          })
-          .setOrigin(0, 0)
-          .setInteractive({ useHandCursor: true })
-          .on('pointerup', () => {
-            if (getTestMode()) {
-              this.scene.start('SelectBoxer');
-            } else {
-              this.scene.start('CreateBoxer');
-            }
-          });
-        nextY = startBtn.y + 40;
-      }
-
-      // Optional reset button and match log link
-      if (getTestMode()) {
-        const resetBtn = this.add
-          .text(tableLeft, nextY, 'Reset data', {
-            font: '20px Arial',
-            color: '#ff0000',
-          })
-          .setOrigin(0, 0)
-          .setInteractive({ useHandCursor: true })
-          .on('pointerup', () => {
-            if (
-              window.confirm(
-                'This will erase saved rankings, stats, and match log. Continue?'
-              )
-            ) {
-              resetSavedData();
-              this.scene.restart();
-            }
-          });
-        nextY = resetBtn.y + 40;
-      }
+      const btnX = width / 2;
+      const btnY = tableBottom + 50;
+      const startBtn = this.add.container(btnX, btnY);
+      startBtn.setSize(500, 80);
+      const bg = this.add.rectangle(0, 0, 500, 80, bgColor, bgAlpha);
+      const label = this.add
+        .text(0, 0, 'Next fight', {
+          font: '32px Arial',
+          color: '#ffffff',
+        })
+        .setOrigin(0.5);
+      const gloveL = this.add
+        .image(-300, 0, 'glove_horizontal')
+        .setDisplaySize(100, 70);
+      const gloveR = this.add
+        .image(300, 0, 'glove_horizontal')
+        .setDisplaySize(100, 70)
+        .setFlipX(true);
+      startBtn.add([bg, label, gloveL, gloveR]);
+      this.tweens.add({
+        targets: gloveL,
+        x: -150,
+        duration: 800,
+        ease: 'Sine.Out',
+      });
+      this.tweens.add({
+        targets: gloveR,
+        x: 150,
+        duration: 800,
+        ease: 'Sine.Out',
+      });
+      const goToSetup = () => {
+        this.scene.start('SelectBoxer');
+      };
+      startBtn
+        .setInteractive({ useHandCursor: true })
+        .on('pointerup', goToSetup);
+      this.input.keyboard.on('keydown-ENTER', goToSetup);
+      this.input.keyboard.on('keydown-SPACE', goToSetup);
     }
   }
 }


### PR DESCRIPTION
## Summary
- Launch StartScene first and wire up options and career navigation
- Streamline RankingScene to show only a centered "Next fight" button

## Testing
- `npm test` *(fails: Could not read package.json)*
- `npm run lint` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689a1f3d1fa8832ab4e13cfd712e192a