### PR TITLE
Fix Phaser import error in startup scenes

### DIFF
--- a/src/scripts/options-scene.js
+++ b/src/scripts/options-scene.js
@@ -1,4 +1,4 @@
-import Phaser from 'phaser';
+// Phaser is loaded globally via a script tag in index.html
 
 export class OptionsScene extends Phaser.Scene {
   constructor() {

--- a/src/scripts/start-scene.js
+++ b/src/scripts/start-scene.js
@@ -1,5 +1,6 @@
-import Phaser from 'phaser';
 import { loadGameState } from './save-system.js';
+
+// Phaser is loaded globally via a script tag in index.html
 
 // Determine if a save game exists.
 const HAS_SAVE = !!loadGameState();


### PR DESCRIPTION
## Summary
- Remove module imports of Phaser in start and options scenes, using global Phaser instead
- Document that Phaser is loaded globally via script tag

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689a21a03e1c832aabd111ba0922b470