### PR TITLE
feat: add intro glove and sound

### DIFF
--- a/src/scripts/main.js
+++ b/src/scripts/main.js
@@ -31,6 +31,10 @@ class BootScene extends Phaser.Scene {
     this.load.audio('left-jab', 'assets/sounds/left-jab.mp3');
     this.load.audio('right-jab', 'assets/sounds/right-jab.mp3');
     this.load.audio('uppercut', 'assets/sounds/uppercut.mp3');
+    this.load.audio(
+      'cinematic-intro',
+      'assets/sounds/cinematic-intro.mp3'
+    );
     this.load.audio('whoosh', 'assets/sounds/whoosh.mp3');
     this.load.audio('stinger', 'assets/sounds/whoosh.mp3');
     this.load.audio('coin_jingle', 'assets/sounds/coin-spill.mp3');
@@ -39,6 +43,10 @@ class BootScene extends Phaser.Scene {
     this.load.image(
       'glove_horizontal',
       'assets/arena/glove-horisontal.png'
+    );
+    this.load.image(
+      'glove_vertical',
+      'assets/arena/glove-vertical.png'
     );
     this.load.image('keyboard', 'assets/arena/keyboard.png');
     this.load.image('computer', 'assets/arena/computer.png');

--- a/src/scripts/sound-manager.js
+++ b/src/scripts/sound-manager.js
@@ -20,6 +20,7 @@ export class SoundManager {
       uppercut: scene.sound.add('uppercut', vol),
       cheer: scene.sound.add('crowd-cheering', vol),
       cheerKO: scene.sound.add('crowd-cheering-ko', vol),
+      cinematicIntro: scene.sound.add('cinematic-intro', vol),
     };
 
     eventBus.on('round-started', () => {
@@ -74,6 +75,12 @@ export class SoundManager {
 
   static playIntro() {
     this.sounds?.intro?.play();
+  }
+
+  static playCinematicIntro() {
+    if (this.cinematicIntroPlayed) return;
+    this.cinematicIntroPlayed = true;
+    this.sounds?.cinematicIntro?.play();
   }
 
   static playBellStart() {

--- a/src/scripts/start-scene.js
+++ b/src/scripts/start-scene.js
@@ -1,4 +1,5 @@
 import { loadGameState } from './save-system.js';
+import { SoundManager } from './sound-manager.js';
 
 // Phaser is loaded globally via a script tag in index.html
 
@@ -48,23 +49,45 @@ export class StartScene extends Phaser.Scene {
       })
       .setOrigin(0.5);
 
-    const items = [
-      {
+    // Glove image with fade-in effect
+    const glove = this.add.image(width / 2, height * 0.32, 'glove_vertical');
+    glove.setDisplaySize(400, 400);
+    glove.setAlpha(0);
+    this.tweens.add({
+      targets: glove,
+      alpha: 1,
+      duration: 800,
+      ease: 'Power2',
+    });
+
+    // Play cinematic intro sound once audio is unlocked
+    if (this.sound.locked) {
+      this.sound.once(Phaser.Sound.Events.UNLOCKED, () => {
+        SoundManager.playCinematicIntro();
+      });
+    } else {
+      SoundManager.playCinematicIntro();
+    }
+
+    const items = [];
+    if (HAS_SAVE) {
+      items.push({
+        label: 'Continue Career',
+        enabled: true,
+        onClick: () => this.goTo(resolveContinueKey()),
+      });
+    } else {
+      items.push({
         label: 'Start New Career',
         enabled: true,
         onClick: () => this.goTo(resolveNewCareerKey()),
-      },
-      {
-        label: 'Continue Career',
-        enabled: HAS_SAVE,
-        onClick: () => this.goTo(resolveContinueKey()),
-      },
-      {
-        label: 'Options',
-        enabled: true,
-        onClick: () => this.goTo(resolveOptionsKey()),
-      },
-    ];
+      });
+    }
+    items.push({
+      label: 'Options',
+      enabled: true,
+      onClick: () => this.goTo(resolveOptionsKey()),
+    });
 
     const spacing = 70;
     const startY = height * 0.4;


### PR DESCRIPTION
## Summary
- preload vertical glove and cinematic intro audio
- show glove with fade-in on start screen and play intro sound once
- hide "Start New Career" when a boxer already exists

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689a26fb9694832aa39df64d7b711669