### PR TITLE
Start cinematic intro on load and lower glove

### DIFF
--- a/src/scripts/main.js
+++ b/src/scripts/main.js
@@ -129,14 +129,18 @@ class BootScene extends Phaser.Scene {
     BackdropManager.init();
 
     const gameSound = this.game.sound;
-    const resume = () => {
+    const unlockAndPlay = () => {
       if (gameSound.context.state === 'suspended') {
         gameSound.context.resume();
       }
       SoundManager.playMenuLoop();
-      document.body.removeEventListener('pointerdown', resume);
     };
-    document.body.addEventListener('pointerdown', resume);
+    unlockAndPlay();
+    if (gameSound.context.state !== 'running') {
+      document.body.addEventListener('pointerdown', unlockAndPlay, {
+        once: true,
+      });
+    }
 
     // Start the overlay scene so match UI elements are ready when needed.
     this.scene.launch('OverlayUI');

--- a/src/scripts/start-scene.js
+++ b/src/scripts/start-scene.js
@@ -51,7 +51,7 @@ export class StartScene extends Phaser.Scene {
 
     // Glove image sweeps in from below
     const gloveStartY = height + 200;
-    const gloveEndY = height * 0.32 + 20;
+    const gloveEndY = height * 0.32 + 40;
     const glove = this.add.image(width / 2, gloveStartY, 'glove_vertical');
     glove.setDisplaySize(400, 400);
     glove.setAlpha(0);


### PR DESCRIPTION
## Summary
- Play cinematic intro automatically when page loads with audio resume fallback
- Drop start-scene glove 20 pixels lower for improved positioning

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/theboxer/package.json')*

------
https://chatgpt.com/codex/tasks/task_e_689a2ad407ec832ab43b84a6c2f129db