### PR TITLE
feat: add options page and dark start backdrop

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -9,7 +9,7 @@
   <style>
     body {
       margin: 0;
-      background: url('assets/arena/backdrop.png') no-repeat center center fixed;
+      background: url('assets/arena/backdrop-dark.png') no-repeat center center fixed;
       background-size: cover;
     }
   </style>

--- a/src/scripts/config.js
+++ b/src/scripts/config.js
@@ -13,3 +13,7 @@ let testMode = params.get('mode') === 'test';
 export function getTestMode() {
   return testMode;
 }
+
+export function setTestMode(val) {
+  testMode = !!val;
+}

--- a/src/scripts/glove-button.js
+++ b/src/scripts/glove-button.js
@@ -1,0 +1,22 @@
+export function createGloveButton(scene, x, y, label, onClick, opts = {}) {
+  const width = opts.width || 500;
+  const height = opts.height || 80;
+  const bgColor = opts.bgColor || 0x001b44;
+  const bgAlpha = opts.bgAlpha || 0.4;
+  const container = scene.add.container(x, y);
+  container.setSize(width, height);
+  const bg = scene.add.rectangle(0, 0, width, height, bgColor, bgAlpha);
+  const text = scene.add.text(0, 0, label, {
+    font: '32px Arial',
+    color: '#ffffff',
+  }).setOrigin(0.5);
+  const gloveStart = width / 2 + 50;
+  const gloveEnd = width / 2 - 100;
+  const gloveL = scene.add.image(-gloveStart, 0, 'glove_horizontal').setDisplaySize(100, 70);
+  const gloveR = scene.add.image(gloveStart, 0, 'glove_horizontal').setDisplaySize(100, 70).setFlipX(true);
+  container.add([bg, text, gloveL, gloveR]);
+  scene.tweens.add({ targets: gloveL, x: -gloveEnd, duration: 800, ease: 'Sine.Out' });
+  scene.tweens.add({ targets: gloveR, x: gloveEnd, duration: 800, ease: 'Sine.Out' });
+  container.setInteractive({ useHandCursor: true }).on('pointerup', () => { if (onClick) onClick(); });
+  return container;
+}

--- a/src/scripts/main.js
+++ b/src/scripts/main.js
@@ -18,6 +18,7 @@ class BootScene extends Phaser.Scene {
 
   preload() {
     console.log('BootScene: preload started');
+    this.load.image('arena_bg_dark', 'assets/arena/backdrop-dark.png');
     this.load.image('ring', 'assets/ring.png');
     this.load.audio('loop-menu', 'assets/sounds/loop-menu.mp3');
     this.load.audio('click-menu', 'assets/sounds/click-menu.mp3');

--- a/src/scripts/options-scene.js
+++ b/src/scripts/options-scene.js
@@ -1,3 +1,8 @@
+import { SoundManager } from './sound-manager.js';
+import { resetSavedData } from './save-system.js';
+import { getTestMode, setTestMode } from './config.js';
+import { createGloveButton } from './glove-button.js';
+
 // Phaser is loaded globally via a script tag in index.html
 
 export class OptionsScene extends Phaser.Scene {
@@ -8,21 +13,69 @@ export class OptionsScene extends Phaser.Scene {
   create() {
     const { width, height } = this.sys.game.config;
 
-    this.add
-      .text(width / 2, height * 0.2, 'Options', {
-        font: '48px Arial',
-        color: '#ffffff',
-      })
-      .setOrigin(0.5);
+    const formHTML = `
+      <div id="opts" style="color:white;font-family:Arial">
+        <div id="soundsGroup">
+          <h2>Sounds</h2>
+          <div id="soundControls"></div>
+        </div>
+        <div id="dataGroup" style="margin-top:20px;">
+          <h2>Data</h2>
+        </div>
+        <div id="debugGroup" style="margin-top:20px;">
+          <h2>Debug</h2>
+          <label><input type="checkbox" id="testModeChk"/> Test mode</label>
+        </div>
+      </div>`;
+
+    const dom = this.add.dom(width / 2, 0).createFromHTML(formHTML);
+    dom.setOrigin(0.5, 0);
+
+    const soundContainer = dom.getChildByID('soundControls');
+    const sliders = {};
+    Object.entries(SoundManager.sounds || {}).forEach(([key, snd]) => {
+      const row = document.createElement('div');
+      row.textContent = key + ': ';
+      const input = document.createElement('input');
+      input.type = 'range';
+      input.min = '0';
+      input.max = '1';
+      input.step = '0.1';
+      input.value = snd.volume.toFixed(1);
+      input.id = `vol_${key}`;
+      row.appendChild(input);
+      soundContainer.appendChild(row);
+      sliders[key] = input;
+    });
+
+    const soundsGroup = dom.getChildByID('soundsGroup');
+    const saveY = soundsGroup.offsetTop + soundsGroup.offsetHeight + 40;
+    createGloveButton(this, width / 2, saveY, 'Save', () => {
+      Object.entries(sliders).forEach(([k, el]) => {
+        const v = parseFloat(el.value);
+        const snd = SoundManager.sounds[k];
+        if (snd) snd.setVolume(v);
+      });
+      SoundManager.saveVolumes();
+    });
+
+    const dataGroup = dom.getChildByID('dataGroup');
+    const clearY = dataGroup.offsetTop + dataGroup.offsetHeight + 40;
+    createGloveButton(this, width / 2, clearY, 'Clear data', () => {
+      resetSavedData();
+    });
+
+    const chk = dom.getChildByID('testModeChk');
+    chk.checked = getTestMode();
+    chk.addEventListener('change', () => setTestMode(chk.checked));
 
     const back = this.add
-      .text(width / 2, height * 0.8, 'Back', {
+      .text(width / 2, height - 40, 'Back', {
         font: '32px Arial',
         color: '#ffffff',
       })
       .setOrigin(0.5)
       .setInteractive({ useHandCursor: true });
-
     const setColor = (hover) => back.setColor(hover ? '#ffff00' : '#ffffff');
     back.on('pointerover', () => setColor(true));
     back.on('pointerout', () => setColor(false));

--- a/src/scripts/ranking-scene.js
+++ b/src/scripts/ranking-scene.js
@@ -4,6 +4,7 @@ import { getPlayerBoxer } from './player-boxer.js';
 import { formatMoney } from './helpers.js';
 import { SoundManager } from './sound-manager.js';
 import { getPendingMatch, clearPendingMatch } from './next-match.js';
+import { createGloveButton } from './glove-button.js';
 import {
   loadGameState,
   applyLoadedState,
@@ -263,43 +264,11 @@ export class RankingScene extends Phaser.Scene {
           this.scene.start('MatchIntroScene', matchData);
         });
     } else {
-      const btnX = width / 2;
       const btnY = tableBottom + 50;
-      const startBtn = this.add.container(btnX, btnY);
-      startBtn.setSize(500, 80);
-      const bg = this.add.rectangle(0, 0, 500, 80, bgColor, bgAlpha);
-      const label = this.add
-        .text(0, 0, 'Next fight', {
-          font: '32px Arial',
-          color: '#ffffff',
-        })
-        .setOrigin(0.5);
-      const gloveL = this.add
-        .image(-300, 0, 'glove_horizontal')
-        .setDisplaySize(100, 70);
-      const gloveR = this.add
-        .image(300, 0, 'glove_horizontal')
-        .setDisplaySize(100, 70)
-        .setFlipX(true);
-      startBtn.add([bg, label, gloveL, gloveR]);
-      this.tweens.add({
-        targets: gloveL,
-        x: -150,
-        duration: 800,
-        ease: 'Sine.Out',
-      });
-      this.tweens.add({
-        targets: gloveR,
-        x: 150,
-        duration: 800,
-        ease: 'Sine.Out',
-      });
       const goToSetup = () => {
         this.scene.start('SelectBoxer');
       };
-      startBtn
-        .setInteractive({ useHandCursor: true })
-        .on('pointerup', goToSetup);
+      createGloveButton(this, width / 2, btnY, 'Next fight', goToSetup);
       this.input.keyboard.on('keydown-ENTER', goToSetup);
       this.input.keyboard.on('keydown-SPACE', goToSetup);
     }

--- a/src/scripts/sound-manager.js
+++ b/src/scripts/sound-manager.js
@@ -23,6 +23,20 @@ export class SoundManager {
       cinematicIntro: scene.sound.add('cinematic-intro', vol),
     };
 
+    try {
+      const raw = localStorage.getItem('theBoxer.volumes');
+      if (raw) {
+        const data = JSON.parse(raw);
+        Object.entries(data).forEach(([k, v]) => {
+          if (this.sounds[k]) {
+            this.sounds[k].setVolume(v);
+          }
+        });
+      }
+    } catch (err) {
+      // ignore
+    }
+
     eventBus.on('round-started', () => {
       if (this.sounds.intro && this.sounds.intro.isPlaying) {
         this.sounds.intro.stop();
@@ -112,5 +126,18 @@ export class SoundManager {
 
   static playCheering() {
     this.sounds?.cheer?.play();
+  }
+
+  static saveVolumes() {
+    if (!this.sounds) return;
+    try {
+      const data = {};
+      Object.entries(this.sounds).forEach(([k, s]) => {
+        data[k] = s.volume;
+      });
+      localStorage.setItem('theBoxer.volumes', JSON.stringify(data));
+    } catch (err) {
+      // ignore
+    }
   }
 }


### PR DESCRIPTION
## Summary
- use dark arena backdrop on start page
- add reusable glove-style button component
- implement full options scene with sound sliders, data reset, and debug toggle
- persist sound volumes and expose test mode setter
- load dark backdrop texture during boot

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689a2e4e4d28832aa6d982c445a36105