### PR TITLE
Fix options scene controls and sound reset

### DIFF
--- a/src/scripts/options-scene.js
+++ b/src/scripts/options-scene.js
@@ -1,6 +1,7 @@
 import { SoundManager } from './sound-manager.js';
 import { resetSavedData } from './save-system.js';
 import { getTestMode, setTestMode } from './config.js';
+import { createGloveButton } from './glove-button.js';
 
 // Phaser is loaded globally via a script tag in index.html
 
@@ -27,12 +28,8 @@ export class OptionsScene extends Phaser.Scene {
         <table>
           <tr><th colspan="2">Sounds</th></tr>
           ${soundRows}
-          <tr><td colspan="2" style="text-align:center;padding-top:10px"><button type="button" id="saveBtn">Save</button></td></tr>
-          <tr><th colspan="2">Data</th></tr>
-          <tr><td colspan="2" style="text-align:center"><button type="button" id="clearBtn">Clear data</button></td></tr>
           <tr><th colspan="2">Debug</th></tr>
           <tr><td colspan="2"><label><input type="checkbox" id="testModeChk"/> Test mode</label></td></tr>
-          <tr><td colspan="2" style="text-align:center;padding-top:10px"><button type="button" id="backBtn">Back</button></td></tr>
         </table>
       </form>`;
 
@@ -43,18 +40,22 @@ export class OptionsScene extends Phaser.Scene {
       sliders[key] = dom.getChildByID(`vol_${key}`);
     });
 
-    dom.getChildByID('saveBtn').addEventListener('click', () => {
+    const save = () => {
       Object.entries(sliders).forEach(([k, el]) => {
         const v = parseFloat(el.value);
         const snd = SoundManager.sounds[k];
         if (snd) snd.setVolume(v);
       });
       SoundManager.saveVolumes();
-    });
+    };
 
-    dom.getChildByID('clearBtn').addEventListener('click', () => {
+    const clear = () => {
       resetSavedData();
-    });
+      Object.entries(sliders).forEach(([k, el]) => {
+        const snd = SoundManager.sounds[k];
+        if (snd) el.value = snd.volume.toFixed(1);
+      });
+    };
 
     const chk = dom.getChildByID('testModeChk');
     chk.checked = getTestMode();
@@ -64,7 +65,20 @@ export class OptionsScene extends Phaser.Scene {
       dom.destroy();
       this.scene.start('StartScene');
     };
-    dom.getChildByID('backBtn').addEventListener('click', goBack);
+
+    const btnY = height * 0.75;
+    createGloveButton(this, width / 2, btnY, 'Save', () => {
+      save();
+      SoundManager.playClick();
+    });
+    createGloveButton(this, width / 2, btnY + 90, 'Clear data', () => {
+      clear();
+      SoundManager.playClick();
+    });
+    createGloveButton(this, width / 2, btnY + 180, 'Back', () => {
+      SoundManager.playClick();
+      goBack();
+    });
 
     this.input.keyboard.on('keydown-ESC', goBack);
     this.input.keyboard.on('keydown-ENTER', goBack);

--- a/src/scripts/save-system.js
+++ b/src/scripts/save-system.js
@@ -1,6 +1,7 @@
 import { BOXERS, resetBoxers, addBoxer } from './boxers.js';
 import { setPlayerBoxer } from './player-boxer.js';
 import { setMatchLog, resetMatchLog, getAllMatchLogs } from './match-log.js';
+import { SoundManager } from './sound-manager.js';
 
 const SAVE_KEY = 'theBoxer.save.v1';
 const VERSION = 1;
@@ -140,6 +141,7 @@ export function resetSavedData() {
       // Ignore
     }
   }
+  SoundManager.resetVolumes();
   resetBoxers();
   setPlayerBoxer(null);
   resetMatchLog();

--- a/src/scripts/sound-manager.js
+++ b/src/scripts/sound-manager.js
@@ -23,6 +23,11 @@ export class SoundManager {
       cinematicIntro: scene.sound.add('cinematic-intro', vol),
     };
 
+    this.defaultVolumes = {};
+    Object.entries(this.sounds).forEach(([k, s]) => {
+      this.defaultVolumes[k] = s.volume;
+    });
+
     try {
       const raw = localStorage.getItem('theBoxer.volumes');
       if (raw) {
@@ -136,6 +141,19 @@ export class SoundManager {
         data[k] = s.volume;
       });
       localStorage.setItem('theBoxer.volumes', JSON.stringify(data));
+    } catch (err) {
+      // ignore
+    }
+  }
+
+  static resetVolumes() {
+    if (!this.sounds) return;
+    Object.entries(this.sounds).forEach(([k, s]) => {
+      const v = this.defaultVolumes ? this.defaultVolumes[k] : undefined;
+      if (v != null) s.setVolume(v);
+    });
+    try {
+      localStorage.removeItem('theBoxer.volumes');
     } catch (err) {
       // ignore
     }


### PR DESCRIPTION
## Summary
- Replace HTML buttons in options scene with animated glove buttons
- Ensure Save reads slider values and Clear Data resets sound settings
- Track default sound volumes and provide reset method

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689a3be6fa78832ab1452685cddeef1b