### PR TITLE
Fix OptionsScene back button error

### DIFF
--- a/src/scripts/options-scene.js
+++ b/src/scripts/options-scene.js
@@ -61,8 +61,14 @@ export class OptionsScene extends Phaser.Scene {
     chk.checked = getTestMode();
     chk.addEventListener('change', () => setTestMode(chk.checked));
 
+    // Ensure the form DOM element is cleaned up when this scene shuts down
+    // rather than destroying it immediately on button press. Destroying the
+    // element during the current render tick caused Phaser to attempt to render
+    // a now-null WebGL texture (glTexture), throwing an error. By waiting for
+    // the shutdown event we let Phaser handle destruction safely.
+    this.events.once(Phaser.Scenes.Events.SHUTDOWN, () => dom.destroy());
+
     const goBack = () => {
-      dom.destroy();
       this.scene.start('StartScene');
     };
 


### PR DESCRIPTION
## Summary
- cleanly destroy options DOM element when scene shuts down
- start StartScene directly on back button press

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689a3e7885f0832a92ade4ca366c2dd5