### PR TITLE
Keep overlay alive when exiting match

### DIFF
--- a/src/scripts/overlay.js
+++ b/src/scripts/overlay.js
@@ -287,10 +287,15 @@ export class OverlayUI extends Phaser.Scene {
     });
 
     const goToRanking = () => {
+      // Stop the active match but keep the overlay scene alive so it can
+      // be reused for future matches. Launch the ranking scene separately
+      // and then sleep + hide the overlay. Using `launch` instead of `start`
+      // ensures this scene isn't shut down, which previously caused the
+      // overlay to disappear in subsequent matches.
       this.scene.stop('MatchScene');
+      this.scene.launch('Ranking');
       this.scene.sleep('OverlayUI');
       this.scene.setVisible('OverlayUI', false);
-      this.scene.start('Ranking');
     };
     this.enterHandler = goToRanking;
     this.clickHandler = goToRanking;


### PR DESCRIPTION
## Summary
- Ensure OverlayUI launches the ranking scene without shutting down, so the overlay remains available for subsequent matches.

## Testing
- `npm test` *(fails: enoent package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689a73787588832a94078d5cd42eb1ff