### PR TITLE
Fix MatchIntroScene freeze between matches

### DIFF
--- a/src/scripts/match-intro-scene.js
+++ b/src/scripts/match-intro-scene.js
@@ -6,7 +6,6 @@ import { makeWhiteTransparent } from './helpers.js';
 export class MatchIntroScene extends Phaser.Scene {
   constructor() {
     super('MatchIntroScene');
-    this._skipHandlersBound = false;
   }
 
   init(data) {
@@ -214,11 +213,8 @@ export class MatchIntroScene extends Phaser.Scene {
       // Scene key for the actual fight is "Match"
       this.scene.start('MatchScene', data);
     };
-    if (!this._skipHandlersBound) {
-      this._skipHandlersBound = true;
-      this.input.keyboard?.on('keydown', startMatch);
-      this.input.on('pointerdown', startMatch);
-    }
+    this.input.keyboard?.once('keydown', startMatch);
+    this.input.once('pointerdown', startMatch);
 
     // --- Manuell kedjning (ersätter timeline) ---
     const chain = (steps) => {


### PR DESCRIPTION
## Summary
- Rebind key and pointer handlers in MatchIntroScene using `once` so skipping to the fight works after the first match.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689a753f2848832abb11660b35bc4e08