### PR TITLE
Reset overlay state between matches

### DIFF
--- a/src/scripts/match-scene.js
+++ b/src/scripts/match-scene.js
@@ -28,6 +28,7 @@ export class MatchScene extends Phaser.Scene {
 
     this.scene.wake('OverlayUI');
     this.scene.setVisible('OverlayUI', true);
+    eventBus.emit('match-started');
 
     const width = this.sys.game.config.width;
     const height = this.sys.game.config.height;
@@ -182,6 +183,11 @@ export class MatchScene extends Phaser.Scene {
     }
 
     this.healthManager = new HealthManager(this.player1, this.player2);
+    this.healthManager.reset();
+    this.player1.adjustStamina(0);
+    this.player2.adjustStamina(0);
+    this.player1.adjustPower(0);
+    this.player2.adjustPower(0);
     this.roundTimer = new RoundTimer(this);
     const makeMgr = (me, opp) => {
       switch (me.stats.ruleset) {

--- a/src/scripts/overlay.js
+++ b/src/scripts/overlay.js
@@ -14,6 +14,7 @@ export class OverlayUI extends Phaser.Scene {
     this.clickHandler = null;
     this.locationText = null;
     this.nextRoundHandler = null;
+    this.onMatchStarted = null;
   }
 
   create() {
@@ -121,6 +122,32 @@ export class OverlayUI extends Phaser.Scene {
     this.setBarValue(this.bars.p2.health, 1);
 
     this.onTimerTick = (seconds) => this.updateTimerText(seconds);
+    this.onMatchStarted = () => {
+      this.matchOver = false;
+      this.continueText?.setVisible(false);
+      this.hideNextRoundButton();
+      this.updateTimerText(0);
+      this.dateText?.setText('');
+      this.locationText?.setText('');
+      this.roundText?.setText('');
+      this.setBarValue(this.bars.p1.stamina, 1);
+      this.setBarValue(this.bars.p1.power, 1);
+      this.setBarValue(this.bars.p1.health, 1);
+      this.setBarValue(this.bars.p2.stamina, 1);
+      this.setBarValue(this.bars.p2.power, 1);
+      this.setBarValue(this.bars.p2.health, 1);
+      this.hits = { p1: 0, p2: 0 };
+      this.score = { p1: 0, p2: 0 };
+      this.updateHitTexts();
+      if (this.enterHandler) {
+        this.input.keyboard.off('keydown', this.enterHandler);
+        this.enterHandler = null;
+      }
+      if (this.clickHandler) {
+        this.input.off('pointerdown', this.clickHandler);
+        this.clickHandler = null;
+      }
+    };
     this.onRoundStarted = (round) => {
       // Ensure the overlay is always rendered above the match scene.
       this.scene.bringToTop();
@@ -187,6 +214,7 @@ export class OverlayUI extends Phaser.Scene {
     eventBus.on('hit-update', this.onHitUpdate);
     eventBus.on('score-update', this.onScoreUpdate);
     eventBus.on('match-date', this.onMatchDate);
+    eventBus.on('match-started', this.onMatchStarted);
 
     this.events.once(Phaser.Scenes.Events.SHUTDOWN, () => {
       eventBus.off('timer-tick', this.onTimerTick);
@@ -200,6 +228,7 @@ export class OverlayUI extends Phaser.Scene {
       eventBus.off('hit-update', this.onHitUpdate);
       eventBus.off('score-update', this.onScoreUpdate);
       eventBus.off('match-date', this.onMatchDate);
+      eventBus.off('match-started', this.onMatchStarted);
     });
   }
 


### PR DESCRIPTION
## Summary
- emit `match-started` from MatchScene to signal new bouts
- reset overlay timer, metadata and status bars when match starts
- refresh stamina and power gauges for both boxers

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689aee62bf4c832a9d42be8b4571a972