### PR TITLE
Ensure three higher-ranked opponents are visible in selection list

### DIFF
--- a/src/scripts/select-boxer-scene.js
+++ b/src/scripts/select-boxer-scene.js
@@ -232,15 +232,11 @@ export class SelectBoxerScene extends Phaser.Scene {
     });
     this.options.push(headerText);
     const player = getPlayerBoxer();
-    const boxers = allBoxers.filter((b) => {
-      if (b === player) return true;
-      // Allow facing any lower-ranked boxer but limit higher-ranked
-      // opponents to within three positions above the player.
-      if (b.ranking < player.ranking) {
-        return b.ranking >= player.ranking - 3;
-      }
-      return true;
-    });
+    // Only show boxers starting three ranks above the player so that
+    // those opponents are visible and selectable while still allowing
+    // any lower-ranked boxer.
+    const minRank = Math.max(1, player.ranking - 3);
+    const boxers = allBoxers.filter((b) => b.ranking >= minRank);
     boxers.forEach((b, i) => {
       const y = 80 + i * 24;
       this.options.push(


### PR DESCRIPTION
## Summary
- show opponent list starting three ranks above the player so higher-ranked opponents are visible and selectable

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/theboxer/package.json')*

------
https://chatgpt.com/codex/tasks/task_e_689af5a37438832a9de0e664aab4b8f7