### PR TITLE
Enable cinematic intro volume slider and commentator control

### DIFF
--- a/src/scripts/comment-manager.js
+++ b/src/scripts/comment-manager.js
@@ -1,4 +1,5 @@
 import { eventBus } from './event-bus.js';
+import { SoundManager } from './sound-manager.js';
 
 export function showComment(text, roundSeconds) {
   eventBus.emit('show-comment', { text, duration: roundSeconds });
@@ -7,7 +8,7 @@ export function showComment(text, roundSeconds) {
 export function speak(text) {
   const utterance = new SpeechSynthesisUtterance(text);
   utterance.lang = 'en-US'; // eller 'sv-SE' för svenska
-  utterance.volume = 1; // 0 till 1
+  utterance.volume = SoundManager.sounds?.commentator?.volume ?? 1; // 0 till 1
   utterance.rate = 0.9; // 0.1 till 10
   utterance.pitch = 1; // 0 till 2
   window.speechSynthesis.speak(utterance);

--- a/src/scripts/sound-manager.js
+++ b/src/scripts/sound-manager.js
@@ -7,9 +7,10 @@ export class SoundManager {
     this.scene = scene;
     const vol = { volume: 0.7 };
     const volLow = { volume: 0.4 };
+    const commentator = { volume: 1, setVolume(v) { this.volume = v; } };
     this.sounds = {
       menuLoop: scene.sound.add('loop-menu', { loop: true, ...vol }),
-      click: scene.sound.add('click-menu', vol+2),
+      click: scene.sound.add('click-menu', vol + 2),
       intro: scene.sound.add('intro', volLow),
       bell: scene.sound.add('bell-signals', vol),
       fight: scene.sound.add('fight', vol),
@@ -20,7 +21,8 @@ export class SoundManager {
       uppercut: scene.sound.add('uppercut', vol),
       cheer: scene.sound.add('crowd-cheering', vol),
       cheerKO: scene.sound.add('crowd-cheering-ko', vol),
-      cinematicIntro: scene.sound.add('cinematic-intro', vol),
+      cinematicIntro: scene.sound.add('cinematic-intro', { ...vol }),
+      commentator,
     };
 
     this.defaultVolumes = {};


### PR DESCRIPTION
## Summary
- Ensure cinematic intro sound uses its own config so its volume slider works
- Allow commentator voice volume to be adjusted and saved

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689aff23232c832aa81226a2c4145076