### PR TITLE
refactor: reuse strategy level dialog

### DIFF
--- a/src/scripts/UIDialogControls.js
+++ b/src/scripts/UIDialogControls.js
@@ -1,0 +1,75 @@
+export function createStrategyLevelSelector(
+  scene,
+  {
+    maxLevel = 10,
+    start = 1,
+    selectLabel = 'Select',
+    defaultLabel = 'Default',
+    onSelect = () => {},
+    locked = false,
+    x = null,
+    y = null,
+  } = {}
+) {
+  const width = scene.sys.game.config.width;
+  const height = scene.sys.game.config.height;
+  const posX = x ?? width / 2;
+  const posY = y ?? height / 2;
+
+  const capRaw = parseInt(maxLevel, 10);
+  const cap = Number.isFinite(capRaw) ? Math.max(1, capRaw) : 4;
+  const startVal = Phaser.Math.Clamp(parseInt(start, 10) || 1, 1, cap);
+
+  const panelHTML = `
+    <div style="background:rgba(0,0,0,0.6);padding:16px 18px;text-align:center;border-radius:10px;color:#fff;min-width:360px;font-family:Arial,sans-serif;">
+      <div style="font-size:18px;margin-bottom:8px;">
+        Strategy level: <span id="strategy-value" style="color:#fff;">${startVal}</span>
+      </div>
+      <input id="strategy-slider" type="range" min="1" max="${cap}" step="1" value="${startVal}" style="width:320px;margin-bottom:12px;" ${locked ? 'disabled' : ''}>
+      <div style="display:flex;gap:12px;justify-content:center;">
+        ${locked ? '' : `<button id="strategy-default" type="button" style="padding:6px 12px;">${defaultLabel}</button>`}
+        <button id="strategy-select" type="button" style="padding:6px 12px;">${selectLabel}</button>
+      </div>
+    </div>
+  `;
+
+  const dom = scene.add.dom(posX, posY).createFromHTML(panelHTML);
+  dom.setOrigin(0.5);
+
+  const slider = dom.getChildByID('strategy-slider');
+  const valueLabel = dom.getChildByID('strategy-value');
+  const selectBtn = dom.getChildByID('strategy-select');
+  const defaultBtn = dom.getChildByID('strategy-default');
+
+  slider.min = '1';
+  slider.max = String(cap);
+  slider.step = '1';
+  slider.value = String(startVal);
+  valueLabel.textContent = String(startVal);
+
+  if (!locked) {
+    slider.addEventListener('input', () => {
+      valueLabel.textContent = slider.value;
+    });
+  }
+
+  const proceed = (level) => {
+    dom.destroy();
+    if (typeof onSelect === 'function') {
+      const lvl =
+        level === 'default'
+          ? 'default'
+          : Phaser.Math.Clamp(parseInt(level, 10) || 1, 1, cap);
+      onSelect(lvl);
+    }
+  };
+
+  selectBtn.addEventListener('click', () => {
+    proceed(locked ? startVal : slider.value);
+  });
+  if (defaultBtn) {
+    defaultBtn.addEventListener('click', () => proceed('default'));
+  }
+
+  return dom;
+}

--- a/src/scripts/select-boxer-scene.js
+++ b/src/scripts/select-boxer-scene.js
@@ -7,6 +7,7 @@ import {
   getPendingMatch,
   clearPendingMatch,
 } from './next-match.js';
+import { createStrategyLevelSelector } from './UIDialogControls.js';
 
 export class SelectBoxerScene extends Phaser.Scene {
   constructor() {
@@ -119,64 +120,13 @@ export class SelectBoxerScene extends Phaser.Scene {
 
   showStrategyOptions(maxLevel) {
     this.clearOptions();
-
-    const width = this.sys.game.config.width;
-    const height = this.sys.game.config.height;
-
-    // Max måste alltid finnas; om saknas/ogiltigt -> 4. Minst 1.
-    const capRaw = parseInt(maxLevel, 10);
-    const cap = Number.isFinite(capRaw) ? Math.max(1, capRaw) : 4;
-    const start = 1;
-
-    const panelHTML = `
-      <div style="background:rgba(0,0,0,0.6);padding:16px 18px;text-align:center;border-radius:10px;color:#fff;min-width:360px;font-family:Arial,sans-serif;">
-        <div style="font-size:18px;margin-bottom:8px;">
-          Strategy level: <span id="strategy-value" style="color:#fff;">${start}</span>
-        </div>
-        <input id="strategy-slider" type="range" min="1" max="${cap}" step="1" value="${start}" style="width:320px;margin-bottom:12px;">
-        <div style="display:flex;gap:12px;justify-content:center;">
-          <button id="strategy-default" type="button" style="padding:6px 12px;">Default</button>
-          <button id="strategy-select"  type="button" style="padding:6px 12px;">Select</button>
-        </div>
-      </div>
-    `;
-
-    const dom = this.add.dom(width / 2, height / 2).createFromHTML(panelHTML);
-    dom.setOrigin(0.5);
-
-    const slider = dom.getChildByID('strategy-slider');
-    const valueLabel = dom.getChildByID('strategy-value');
-    const defaultBtn = dom.getChildByID('strategy-default');
-    const selectBtn = dom.getChildByID('strategy-select');
-
-    // Säkerställ gränser & startvärde
-    slider.min = '1';
-    slider.max = String(cap);
-    slider.step = '1';
-    slider.value = String(start);
-    valueLabel.textContent = String(start);
-
-    // Live-uppdatering
-    slider.addEventListener('input', () => {
-      valueLabel.textContent = slider.value;
+    const dom = createStrategyLevelSelector(this, {
+      maxLevel,
+      onSelect: (level) => {
+        this.options = (this.options || []).filter((o) => o !== dom);
+        this.selectStrategy(level);
+      },
     });
-
-    // Städa och gå vidare
-    const proceed = (level) => {
-      dom.destroy();
-      this.options = (this.options || []).filter((o) => o !== dom);
-
-      const lvl =
-        level === 'default'
-          ? 'default'
-          : Phaser.Math.Clamp(parseInt(level, 10) || 1, 1, cap);
-
-      this.selectStrategy(lvl);
-    };
-
-    defaultBtn.addEventListener('click', () => proceed('default'));
-    selectBtn.addEventListener('click', () => proceed(slider.value));
-
     (this.options ||= []).push(dom);
   }
 


### PR DESCRIPTION
## Summary
- add reusable `createStrategyLevelSelector` dialog with optional locking
- use shared strategy dialog when starting a match and during round breaks

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689b021b96d8832aa1b5b3f18d88ba04