### PR TITLE
Enable escape key options and pausing

### DIFF
--- a/src/scripts/match-scene.js
+++ b/src/scripts/match-scene.js
@@ -720,6 +720,7 @@ export class MatchScene extends Phaser.Scene {
       this.roundTimer.pause();
       this.player1.sprite.anims.pause();
       this.player2.sprite.anims.pause();
+      showComment('Match paused. Press Shift+P to resume.', 5);
     } else {
       this.roundTimer.resume();
       this.player1.sprite.anims.resume();

--- a/src/scripts/options-scene.js
+++ b/src/scripts/options-scene.js
@@ -6,10 +6,14 @@ import { getTestMode, setTestMode } from './config.js';
 // Phaser laddas globalt via script-tag
 
 export class OptionsScene extends Phaser.Scene {
-  constructor() { super('OptionsScene'); }
+  constructor() {
+    super('OptionsScene');
+  }
 
-  create() {
+  create(data) {
     this._leaving = false;
+    this.returnScene = data?.fromScene;
+    this.overlayActive = data?.overlayActive;
 
     const W = this.scale.width;
     const H = this.scale.height;
@@ -141,9 +145,17 @@ export class OptionsScene extends Phaser.Scene {
     });
 
     const back = () => {
-      if (this._leaving) return;   // skydda mot dubbelklick
+      if (this._leaving) return; // skydda mot dubbelklick
       this._leaving = true;
-      this.scene.start('StartScene');
+      this.scene.stop();
+      if (this.overlayActive) {
+        this.scene.resume('OverlayUI');
+      }
+      if (this.returnScene) {
+        this.scene.resume(this.returnScene);
+      } else {
+        this.scene.start('StartScene');
+      }
     };
     makeLink('Back', panelX + panelW * 0.78, back);
 


### PR DESCRIPTION
## Summary
- Let Escape open the options from any scene and pause the current scene
- Return from options to the previous scene and resume overlay if needed
- Show commentator hint when matches are paused

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689b07f18cd8832a84424e687142220e