### PR TITLE
Stop menu loop during match intro

### DIFF
--- a/src/scripts/match-intro-scene.js
+++ b/src/scripts/match-intro-scene.js
@@ -2,6 +2,7 @@
 // Phaser 3 scen för “Tale of the Tape” utan timeline-API (manuell kedjning av tweens)
 
 import { makeWhiteTransparent } from './helpers.js';
+import { SoundManager } from './sound-manager.js';
 
 export class MatchIntroScene extends Phaser.Scene {
   constructor() {
@@ -22,6 +23,10 @@ export class MatchIntroScene extends Phaser.Scene {
   }
 
   create() {
+    SoundManager.stopMenuLoop();
+    if (!SoundManager.sounds?.intro?.isPlaying) {
+      SoundManager.playIntro();
+    }
     const data = this.matchData;
     const { width, height } = this.scale;
 


### PR DESCRIPTION
## Summary
- Stop persistent menu music by halting it when MatchIntroScene starts and triggering intro audio

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689b0a91c1e8832aaa55fef1af397f05