### PR TITLE
Use range slider for round selection and display scheduled rounds

### DIFF
--- a/src/scripts/UIDialogControls.js
+++ b/src/scripts/UIDialogControls.js
@@ -73,3 +73,55 @@ export function createStrategyLevelSelector(
 
   return dom;
 }
+
+export function createRoundSelector(
+  scene,
+  {
+    maxRounds = 13,
+    start = 1,
+    selectLabel = 'Select',
+    onSelect = () => {},
+    x = null,
+    y = null,
+  } = {},
+) {
+  const width = scene.sys.game.config.width;
+  const height = scene.sys.game.config.height;
+  const posX = x ?? width / 2;
+  const posY = y ?? height / 2;
+
+  const capRaw = parseInt(maxRounds, 10);
+  const cap = Number.isFinite(capRaw) ? Math.max(1, capRaw) : 13;
+  const startVal = Phaser.Math.Clamp(parseInt(start, 10) || 1, 1, cap);
+
+  const panelHTML = `
+    <div style="background:rgba(0,0,0,0.6);padding:16px 18px;text-align:center;border-radius:10px;color:#fff;min-width:360px;font-family:Arial,sans-serif;">
+      <div style="font-size:18px;margin-bottom:8px;">
+        Rounds: <span id="round-value">${startVal}</span>
+      </div>
+      <input id="round-slider" type="range" min="1" max="${cap}" step="1" value="${startVal}" style="width:320px;margin-bottom:12px;">
+      <div>
+        <button id="round-select" type="button" style="padding:6px 12px;">${selectLabel}</button>
+      </div>
+    </div>
+  `;
+
+  const dom = scene.add.dom(posX, posY).createFromHTML(panelHTML);
+  dom.setOrigin(0.5);
+
+  const slider = dom.getChildByID('round-slider');
+  const valueLabel = dom.getChildByID('round-value');
+  const selectBtn = dom.getChildByID('round-select');
+
+  slider.addEventListener('input', () => {
+    valueLabel.textContent = slider.value;
+  });
+
+  selectBtn.addEventListener('click', () => {
+    const val = Phaser.Math.Clamp(parseInt(slider.value, 10) || 1, 1, cap);
+    dom.destroy();
+    if (typeof onSelect === 'function') onSelect(val);
+  });
+
+  return dom;
+}

--- a/src/scripts/match-intro-scene.js
+++ b/src/scripts/match-intro-scene.js
@@ -123,8 +123,9 @@ export class MatchIntroScene extends Phaser.Scene {
       })
       .setOrigin(0.5);
     infoContainer.add(dateText);
+    const totalRounds = Phaser.Math.Clamp(data?.rounds || 1, 1, 13);
     const scheduleText = this.add
-      .text(0, 60, 'Scheduled for 3 rounds', {
+      .text(0, 60, `Scheduled for ${totalRounds} rounds`, {
         fontFamily: 'Arial',
         fontSize: '22px',
         color: '#FFFFFF',

--- a/src/scripts/overlay.js
+++ b/src/scripts/overlay.js
@@ -257,7 +257,9 @@ export class OverlayUI extends Phaser.Scene {
 
   showRound(number) {
     if (!this.roundText) return;
-    this.roundText.setText(`Round ${number}`);
+    const matchScene = this.scene.get('MatchScene');
+    const total = matchScene?.maxRounds ?? number;
+    this.roundText.setText(`Round ${number} (scheduled for ${total} rounds)`);
   }
 
   setNames(p1, p2) {

--- a/src/scripts/select-boxer-scene.js
+++ b/src/scripts/select-boxer-scene.js
@@ -7,7 +7,7 @@ import {
   getPendingMatch,
   clearPendingMatch,
 } from './next-match.js';
-import { createStrategyLevelSelector } from './UIDialogControls.js';
+import { createStrategyLevelSelector, createRoundSelector } from './UIDialogControls.js';
 
 export class SelectBoxerScene extends Phaser.Scene {
   constructor() {
@@ -287,7 +287,6 @@ export class SelectBoxerScene extends Phaser.Scene {
       this.choice.push(boxer);
       this.selectedStrategy2 = 'default';
       this.step = 3;
-      this.instruction.setText('Choose number of rounds (1-13)');
       this.showRoundOptions();
       return;
     }
@@ -318,7 +317,6 @@ export class SelectBoxerScene extends Phaser.Scene {
       } else {
         this.selectedStrategy2 = 'default';
         this.step = 5;
-        this.instruction.setText('Choose number of rounds (1-13)');
         this.showRoundOptions();
       }
     }
@@ -342,23 +340,18 @@ export class SelectBoxerScene extends Phaser.Scene {
       // test mode: opponent strategy selection
       this.selectedStrategy2 = level;
       this.step = 5;
-      this.instruction.setText('Choose number of rounds (1-13)');
       this.showRoundOptions();
     }
   }
 
-  showRoundOptions() {
+  showRoundOptions(maxRounds = 13) {
     this.clearOptions();
-    for (let i = 1; i <= 13; i++) {
-      const y = 60 + i * 25;
-      const txt = this.add.text(50, y, `${i}`, {
-        font: '20px Arial',
-        color: '#ffffff',
-      });
-      txt.setInteractive({ useHandCursor: true });
-      txt.on('pointerdown', () => this.selectRounds(i));
-      this.options.push(txt);
-    }
+    this.instruction.setText(`Choose number of rounds (1-${maxRounds})`);
+    const dom = createRoundSelector(this, {
+      maxRounds,
+      onSelect: (val) => this.selectRounds(val),
+    });
+    this.options.push(dom);
   }
 
   selectRounds(num) {


### PR DESCRIPTION
## Summary
- Add reusable round selector with range slider
- Show slider when choosing rounds and display scheduled round count during fights
- Populate intro screen with correct number of rounds

## Testing
- `npm test` (fails: ENOENT no package.json)

------
https://chatgpt.com/codex/tasks/task_e_689b0e1bd5a0832a957ecc3bdbfba45d