### PR TITLE
feat: add game result scene

### DIFF
--- a/src/scripts/game-result-scene.js
+++ b/src/scripts/game-result-scene.js
@@ -1,0 +1,110 @@
+import { formatMoney, makeWhiteTransparent } from './helpers.js';
+import { SoundManager } from './sound-manager.js';
+
+export class GameResultScene extends Phaser.Scene {
+  constructor() {
+    super('GameResultScene');
+  }
+
+  init(data) {
+    this.resultData = data || {};
+  }
+
+  create() {
+    const width = this.sys.game.config.width;
+    const height = this.sys.game.config.height;
+    SoundManager.playMenuLoop();
+
+    this.add
+      .text(width / 2, 20, 'Match Result', {
+        font: '32px Arial',
+        color: '#ffffff',
+      })
+      .setOrigin(0.5, 0);
+
+    const rounds = Array.isArray(this.resultData.roundLog)
+      ? this.resultData.roundLog
+      : [];
+    let y = 80;
+    rounds.forEach((r) => {
+      const line = `Round ${r.round}: ${r.p1Score}-${r.p2Score} (${r.totalP1}-${r.totalP2})`;
+      this.add.text(width / 2, y, line, {
+        font: '24px Arial',
+        color: '#ffffff',
+      }).setOrigin(0.5);
+      y += 30;
+    });
+    y += 20;
+
+    const b1 = this.resultData.b1 || {};
+    const b2 = this.resultData.b2 || {};
+    const b1RankChange =
+      b1.rankingBefore != null && b1.rankingAfter != null
+        ? b1.rankingBefore - b1.rankingAfter
+        : 0;
+    const b2RankChange =
+      b2.rankingBefore != null && b2.rankingAfter != null
+        ? b2.rankingBefore - b2.rankingAfter
+        : 0;
+    const b1Line = `${b1.name || 'Boxer 1'}: ${formatMoney(b1.prize)}  Rank ${
+      b1.rankingBefore ?? '-'
+    }→${b1.rankingAfter ?? '-'}${b1RankChange > 0 ? ' ↑' : ''}`;
+    const b2Line = `${b2.name || 'Boxer 2'}: ${formatMoney(b2.prize)}  Rank ${
+      b2.rankingBefore ?? '-'
+    }→${b2.rankingAfter ?? '-'}${b2RankChange > 0 ? ' ↑' : ''}`;
+    this.add
+      .text(width / 2, y, b1Line, { font: '28px Arial', color: '#ffffff' })
+      .setOrigin(0.5);
+    this.add
+      .text(width / 2, y + 40, b2Line, { font: '28px Arial', color: '#ffffff' })
+      .setOrigin(0.5);
+    y += 100;
+
+    const belts = Array.isArray(this.resultData.titlesWon)
+      ? this.resultData.titlesWon
+      : [];
+    if (belts.length > 0) {
+      const beltY = y;
+      const beltW = 220;
+      const spacing = 20;
+      const totalW = belts.length * beltW + (belts.length - 1) * spacing;
+      let startX = (width - totalW) / 2 + beltW / 2;
+      belts.forEach((b) => {
+        const imgKey = makeWhiteTransparent(this, b.imageKey || b.code || b);
+        const belt = this.add.image(startX, beltY, imgKey).setOrigin(0.5);
+        belt.setDisplaySize(beltW, beltW * 0.5);
+        startX += beltW + spacing;
+      });
+      y = beltY + beltW * 0.5 + 60;
+    }
+
+    const emitter = this.add.particles(0, 0, 'coin', {
+      x: { min: width / 2 - 250, max: width / 2 + 250 },
+      y: { min: -150, max: -50 },
+      speedY: { min: 200, max: 400 },
+      lifespan: 2000,
+      quantity: 2,
+      frequency: 80,
+      scale: { start: 0.7, end: 0.2 },
+      alpha: { start: 1, end: 0 },
+      emitting: true,
+    }).setDepth(10);
+    this.time.delayedCall(1200, () => emitter.stop());
+
+    const contY = height - 60;
+    const cont = this.add
+      .text(width / 2, contY, 'Continue', {
+        font: '32px Arial',
+        color: '#ffffff',
+      })
+      .setOrigin(0.5)
+      .setInteractive({ useHandCursor: true });
+
+    const goRanking = () => {
+      this.scene.start('Ranking');
+    };
+    cont.once('pointerup', goRanking);
+    this.input.keyboard.once('keydown', goRanking);
+  }
+}
+

--- a/src/scripts/main.js
+++ b/src/scripts/main.js
@@ -10,6 +10,7 @@ import { OptionsScene } from './options-scene.js';
 import { BackdropManager } from './backdrop-manager.js';
 import { MatchIntroScene } from './match-intro-scene.js';
 import { TITLES } from './title-data.js';
+import { GameResultScene } from './game-result-scene.js';
 
 class BootScene extends Phaser.Scene {
   constructor() {
@@ -169,6 +170,7 @@ const config = {
     SelectBoxerScene,
     MatchIntroScene,
     MatchScene,
+    GameResultScene,
     OverlayUI,
   ],
 };

--- a/src/scripts/match-scene.js
+++ b/src/scripts/match-scene.js
@@ -456,6 +456,8 @@ export class MatchScene extends Phaser.Scene {
     const rank2 = b2.ranking;
     const before1 = b1.earnings || 0;
     const before2 = b2.earnings || 0;
+    const titles1Before = (b1.titles || []).slice();
+    const titles2Before = (b2.titles || []).slice();
     recordResult(winner.stats, loser.stats, 'KO');
     const prize1 = b1.earnings - before1;
     const prize2 = b2.earnings - before2;
@@ -502,6 +504,24 @@ export class MatchScene extends Phaser.Scene {
       roundDetails: roundDetails2,
     });
     saveGameState(BOXERS);
+    const winnerBefore = winner === this.player1 ? titles1Before : titles2Before;
+    const gained = (winner.stats.titles || []).filter((t) => !winnerBefore.includes(t));
+    this.resultData = {
+      b1: {
+        name: b1.name,
+        prize: prize1,
+        rankingBefore: rank1,
+        rankingAfter: b1.ranking,
+      },
+      b2: {
+        name: b2.name,
+        prize: prize2,
+        rankingBefore: rank2,
+        rankingAfter: b2.ranking,
+      },
+      roundLog: this.roundLog,
+      titlesWon: gained.map((code) => ({ code })),
+    };
   }
 
   determineWinnerByPoints() {
@@ -515,6 +535,8 @@ export class MatchScene extends Phaser.Scene {
     const score2 = this.score.p2;
     const before1 = b1.earnings || 0;
     const before2 = b2.earnings || 0;
+    const titles1Before = (b1.titles || []).slice();
+    const titles2Before = (b2.titles || []).slice();
     const roundDetails1 = this.roundLog.map((r) => ({
       round: r.round,
       userScore: r.p1Score,
@@ -570,6 +592,22 @@ export class MatchScene extends Phaser.Scene {
         roundDetails: roundDetails2,
       });
       saveGameState(BOXERS);
+      this.resultData = {
+        b1: {
+          name: b1.name,
+          prize: prize1,
+          rankingBefore: rank1,
+          rankingAfter: b1.ranking,
+        },
+        b2: {
+          name: b2.name,
+          prize: prize2,
+          rankingBefore: rank2,
+          rankingAfter: b2.ranking,
+        },
+        roundLog: this.roundLog,
+        titlesWon: [],
+      };
       return;
     }
 
@@ -618,6 +656,28 @@ export class MatchScene extends Phaser.Scene {
       roundDetails: roundDetails2,
     });
     saveGameState(BOXERS);
+    const winnerBefore = winner === this.player1 ? titles1Before : titles2Before;
+    const gained = (winner.stats.titles || []).filter((t) => !winnerBefore.includes(t));
+    this.resultData = {
+      b1: {
+        name: b1.name,
+        prize: prize1,
+        rankingBefore: rank1,
+        rankingAfter: b1.ranking,
+      },
+      b2: {
+        name: b2.name,
+        prize: prize2,
+        rankingBefore: rank2,
+        rankingAfter: b2.ranking,
+      },
+      roundLog: this.roundLog,
+      titlesWon: gained.map((code) => ({ code })),
+    };
+  }
+
+  getResultData() {
+    return this.resultData;
   }
 
   setPlayerStrategy(player, level) {

--- a/src/scripts/overlay.js
+++ b/src/scripts/overlay.js
@@ -318,19 +318,20 @@ export class OverlayUI extends Phaser.Scene {
       },
     });
 
-    const goToRanking = () => {
+    const goToResults = () => {
       // Stop the active match but keep the overlay scene alive so it can
-      // be reused for future matches. Launch the ranking scene separately
+      // be reused for future matches. Launch the results scene separately
       // and then sleep + hide the overlay. Using `launch` instead of `start`
       // ensures this scene isn't shut down, which previously caused the
       // overlay to disappear in subsequent matches.
+      const data = this.scene.get('MatchScene')?.getResultData?.();
       this.scene.stop('MatchScene');
-      this.scene.launch('Ranking');
+      this.scene.launch('GameResultScene', data);
       this.scene.sleep('OverlayUI');
       this.scene.setVisible('OverlayUI', false);
     };
-    this.enterHandler = goToRanking;
-    this.clickHandler = goToRanking;
+    this.enterHandler = goToResults;
+    this.clickHandler = goToResults;
     this.input.keyboard.once('keydown', this.enterHandler);
     this.input.once('pointerdown', this.clickHandler);
   }


### PR DESCRIPTION
## Summary
- add GameResultScene with per-round summary, prize payouts, ranking shifts, and belt transfers
- collect match result data including prizes, ranking changes, and titles won
- show GameResultScene after matches before returning to ranking

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689b16153600832a9ff12e65109b0b71