### PR TITLE
Add calendar scene and match simulation flow

### DIFF
--- a/src/scripts/calendar-scene.js
+++ b/src/scripts/calendar-scene.js
@@ -1,0 +1,82 @@
+import { generateMonthlyMatches, simulateMatch } from './calendar.js';
+import { getPendingMatch, clearPendingMatch } from './next-match.js';
+import { getMatchLog } from './match-log.js';
+import { SoundManager } from './sound-manager.js';
+
+export class CalendarScene extends Phaser.Scene {
+  constructor() {
+    super('Calendar');
+    this.matches = [];
+    this.currentIndex = 0;
+    this.rows = [];
+  }
+
+  create() {
+    const width = this.sys.game.config.width;
+    SoundManager.playMenuLoop();
+    const pending = getPendingMatch();
+    if (!pending) {
+      // No scheduled player match, return to rankings
+      this.scene.start('Ranking');
+      return;
+    }
+
+    const { matches } = generateMonthlyMatches(getMatchLog().length, [
+      pending.boxer1.name,
+      pending.boxer2.name,
+    ]);
+    // Player match is always last
+    this.matches = [...matches, { ...pending, player: true }];
+
+    this.title = this.add
+      .text(width / 2, 20, 'Upcoming Matches', {
+        font: '32px Arial',
+        color: '#ffffff',
+      })
+      .setOrigin(0.5, 0);
+
+    this.render();
+  }
+
+  formatLine(match) {
+    let line = `${match.date} ${match.boxer1.name} vs ${match.boxer2.name}`;
+    if (match.result) {
+      line += ` - ${match.result.winner} ${match.result.method}`;
+    }
+    return line;
+  }
+
+  render() {
+    this.rows.forEach((r) => r.destroy());
+    this.rows = [];
+    const width = this.sys.game.config.width;
+    const startY = 80;
+    this.matches.forEach((m, i) => {
+      const txt = this.add
+        .text(width / 2, startY + i * 40, this.formatLine(m), {
+          font: '24px Arial',
+          color: '#ffffff',
+        })
+        .setOrigin(0.5, 0);
+      if (!m.result && i === this.currentIndex) {
+        txt.setColor('#00ff00');
+        txt.setInteractive({ useHandCursor: true });
+        txt.on('pointerup', () => this.handleMatch(m));
+      }
+      this.rows.push(txt);
+    });
+  }
+
+  async handleMatch(match) {
+    if (match.player) {
+      const matchData = { ...match, red: match.boxer1, blue: match.boxer2 };
+      clearPendingMatch();
+      this.scene.start('MatchIntroScene', matchData);
+      return;
+    }
+    await simulateMatch(match, 500);
+    this.currentIndex += 1;
+    this.render();
+  }
+}
+

--- a/src/scripts/main.js
+++ b/src/scripts/main.js
@@ -11,6 +11,7 @@ import { BackdropManager } from './backdrop-manager.js';
 import { MatchIntroScene } from './match-intro-scene.js';
 import { TITLES } from './title-data.js';
 import { GameResultScene } from './game-result-scene.js';
+import { CalendarScene } from './calendar-scene.js';
 
 class BootScene extends Phaser.Scene {
   constructor() {
@@ -168,6 +169,7 @@ const config = {
     CreateBoxerScene,
     OptionsScene,
     SelectBoxerScene,
+    CalendarScene,
     MatchIntroScene,
     MatchScene,
     GameResultScene,

--- a/src/scripts/select-boxer-scene.js
+++ b/src/scripts/select-boxer-scene.js
@@ -2,11 +2,7 @@ import { getRankings, getMatchPreview } from './boxer-stats.js';
 import { getTestMode, tableAlpha } from './config.js';
 import { getPlayerBoxer } from './player-boxer.js';
 import { SoundManager } from './sound-manager.js';
-import {
-  scheduleMatch,
-  getPendingMatch,
-  clearPendingMatch,
-} from './next-match.js';
+import { scheduleMatch, getPendingMatch } from './next-match.js';
 import { createStrategyLevelSelector, createRoundSelector } from './UIDialogControls.js';
 
 export class SelectBoxerScene extends Phaser.Scene {
@@ -365,13 +361,8 @@ export class SelectBoxerScene extends Phaser.Scene {
     scheduleMatch({ boxer1, boxer2, aiLevel1, aiLevel2, rounds });
     const pending = getPendingMatch();
     if (pending) {
-      const matchData = {
-        ...pending,
-        red: pending.boxer1,
-        blue: pending.boxer2,
-      };
-      clearPendingMatch();
-      this.scene.start('MatchIntroScene', matchData);
+      // Go to calendar to simulate other matches before the player's fight
+      this.scene.start('Calendar');
     } else {
       this.scene.start('Ranking');
     }


### PR DESCRIPTION
## Summary
- introduce CalendarScene to list monthly bouts and simulate non-player fights before the player's match
- redirect SelectBoxerScene to calendar after scheduling a fight
- register CalendarScene in main game configuration

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689b2db2fe64832a9e16a1db42e89d29