### PR TITLE
Simulate pending matches before player fight

### DIFF
--- a/src/scripts/calendar-scene.js
+++ b/src/scripts/calendar-scene.js
@@ -119,13 +119,25 @@ export class CalendarScene extends Phaser.Scene {
     });
   }
 
+  async simulatePendingMatches() {
+    const pending = this.matches.filter((m) => !m.result && !m.player);
+    for (const m of pending) {
+      await simulateMatch(m, 3000);
+      this.render();
+    }
+  }
+
   async simulate(match) {
+    if (match.player) {
+      await this.simulatePendingMatches();
+    }
     await simulateMatch(match, 500);
     this.render();
   }
 
-  playMatch(match, index) {
+  async playMatch(match, index) {
     if (match.player) {
+      await this.simulatePendingMatches();
       const matchData = {
         ...match,
         red: match.boxer1,


### PR DESCRIPTION
## Summary
- Simulate all unsimulated AI fights in order with a 3 second delay before the player's match
- Ensure player's match waits for pending simulations whether it's simulated or played

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689b38270f30832aaeceb49e8273baeb