### PR TITLE
Implement monthly calendar system with persistent date

### DIFF
--- a/src/scripts/calendar-scene.js
+++ b/src/scripts/calendar-scene.js
@@ -30,7 +30,7 @@ export class CalendarScene extends Phaser.Scene {
     if (stored && stored.length > 0) {
       this.matches = stored;
     } else {
-      const { matches } = generateMonthlyMatches(getMatchLog().length, [
+      const { matches } = generateMonthlyMatches([
         pending.boxer1.name,
         pending.boxer2.name,
       ]);

--- a/src/scripts/calendar.js
+++ b/src/scripts/calendar.js
@@ -1,6 +1,7 @@
 import { BOXERS } from './boxers.js';
 import { recordResult } from './boxer-stats.js';
 import { addMatchLog } from './match-log.js';
+import { getCurrentDate } from './game-date.js';
 
 let currentMatches = null;
 
@@ -26,10 +27,10 @@ export function hasPendingMatches() {
   return !!currentMatches?.some((m) => !m.result);
 }
 
-function computeRange(matchIndex) {
-  const baseDate = new Date(2025, 2, 5); // March 5, 2025
-  const upcoming = new Date(baseDate);
-  upcoming.setMonth(baseDate.getMonth() + matchIndex);
+function computeRange() {
+  const current = getCurrentDate();
+  const upcoming = new Date(current);
+  upcoming.setMonth(current.getMonth() + 1, 5);
   const start = new Date(upcoming.getFullYear(), upcoming.getMonth() - 1, 6);
   const end = new Date(upcoming.getFullYear(), upcoming.getMonth(), 4);
   return { start, end };
@@ -48,8 +49,8 @@ function pickRandom(pool) {
   return pool.splice(index, 1)[0];
 }
 
-export function generateMonthlyMatches(matchIndex, excluded = []) {
-  const { start, end } = computeRange(matchIndex);
+export function generateMonthlyMatches(excluded = []) {
+  const { start, end } = computeRange();
   const exclude = new Set(excluded);
   const lowRank = BOXERS.filter(
     (b) => b.ranking >= 50 && !exclude.has(b.name)

--- a/src/scripts/game-date.js
+++ b/src/scripts/game-date.js
@@ -1,0 +1,37 @@
+import { BOXERS } from './boxers.js';
+
+let currentDate = new Date(2025, 1, 5); // February 5, 2025
+
+export function getCurrentDate() {
+  return new Date(currentDate);
+}
+
+export function setCurrentDate(date) {
+  if (date instanceof Date && !isNaN(date)) {
+    currentDate = new Date(date);
+  }
+}
+
+export function resetDate() {
+  currentDate = new Date(2025, 1, 5);
+}
+
+export function advanceMonth() {
+  const prevMonth = currentDate.getMonth();
+  currentDate.setMonth(currentDate.getMonth() + 1, 5);
+  if (currentDate.getMonth() === 0 && prevMonth === 11) {
+    BOXERS.forEach((b) => {
+      b.age += 1;
+    });
+  }
+}
+
+export function formatDate(date) {
+  return date
+    .toLocaleDateString('en-GB', {
+      day: 'numeric',
+      month: 'long',
+      year: 'numeric',
+    })
+    .toLowerCase();
+}

--- a/src/scripts/game-result-scene.js
+++ b/src/scripts/game-result-scene.js
@@ -1,6 +1,7 @@
 import { formatMoney, makeWhiteTransparent } from './helpers.js';
 import { SoundManager } from './sound-manager.js';
 import { updateMatchResult, clearCurrentMatches } from './calendar.js';
+import { advanceMonth } from './game-date.js';
 
 export class GameResultScene extends Phaser.Scene {
   constructor() {
@@ -115,6 +116,7 @@ export class GameResultScene extends Phaser.Scene {
         this.scene.start('Calendar');
       } else {
         clearCurrentMatches();
+        advanceMonth();
         this.scene.start('Ranking');
       }
     };

--- a/src/scripts/match-scene.js
+++ b/src/scripts/match-scene.js
@@ -17,6 +17,7 @@ import { BOXERS } from './boxers.js';
 import { saveGameState } from './save-system.js';
 import { addMatchLog } from './match-log.js';
 import { getTestMode } from './config.js';
+import { getCurrentDate } from './game-date.js';
 
 export class MatchScene extends Phaser.Scene {
   constructor() {
@@ -125,10 +126,9 @@ export class MatchScene extends Phaser.Scene {
       let year = data?.year;
       let dateStr = data?.date;
       if (!year || !dateStr) {
-        const logCount = getMatchLog().length;
-        const baseDate = new Date(2025, 2, 5); // March 5, 2025
-        const matchDate = new Date(baseDate);
-        matchDate.setDate(baseDate.getDate() + logCount * 20);
+        const current = getCurrentDate();
+        const matchDate = new Date(current);
+        matchDate.setMonth(current.getMonth() + 1, 5);
         year = matchDate.getFullYear();
         const ds = matchDate.toLocaleDateString('sv-SE', {
           day: 'numeric',

--- a/src/scripts/next-match.js
+++ b/src/scripts/next-match.js
@@ -1,14 +1,13 @@
 import { ArenaManager } from './arena-manager.js';
-import { getMatchLog } from './match-log.js';
 import { getMatchPreview } from './boxer-stats.js';
+import { getCurrentDate } from './game-date.js';
 
 let pendingMatch = null;
 
 function computeDate() {
-  const logCount = getMatchLog().length;
-  const baseDate = new Date(2025, 2, 5);
-  const matchDate = new Date(baseDate);
-  matchDate.setMonth(baseDate.getMonth() + logCount);
+  const current = getCurrentDate();
+  const matchDate = new Date(current);
+  matchDate.setMonth(current.getMonth() + 1, 5);
   const year = matchDate.getFullYear();
   const dateStr = matchDate.toLocaleDateString('sv-SE', {
     day: 'numeric',

--- a/src/scripts/ranking-scene.js
+++ b/src/scripts/ranking-scene.js
@@ -3,6 +3,7 @@ import { appConfig } from './config.js';
 import { getPlayerBoxer } from './player-boxer.js';
 import { formatMoney } from './helpers.js';
 import { SoundManager } from './sound-manager.js';
+import { getCurrentDate, formatDate } from './game-date.js';
 import { getPendingMatch, clearPendingMatch } from './next-match.js';
 import { createGloveButton } from './glove-button.js';
 import {
@@ -37,8 +38,9 @@ export class RankingScene extends Phaser.Scene {
 
     // Position the ranking title near the top
     const headerY = 20;
+    const dateStr = formatDate(getCurrentDate());
     this.add
-      .text(width / 2, headerY, 'Ranking', {
+      .text(width / 2, headerY, `Ranking - ${dateStr}`, {
         font: '32px Arial',
         color: '#ffffff',
       })

--- a/src/scripts/save-system.js
+++ b/src/scripts/save-system.js
@@ -2,6 +2,7 @@ import { BOXERS, resetBoxers, addBoxer } from './boxers.js';
 import { setPlayerBoxer } from './player-boxer.js';
 import { setMatchLog, resetMatchLog, getAllMatchLogs } from './match-log.js';
 import { SoundManager } from './sound-manager.js';
+import { getCurrentDate, setCurrentDate, resetDate } from './game-date.js';
 
 const SAVE_KEY = 'theBoxer.save.v1';
 const VERSION = 1;
@@ -30,6 +31,7 @@ export function saveGameState(boxers) {
     const payload = {
       version: VERSION,
       lastUpdatedUtc: new Date().toISOString(),
+      currentDate: getCurrentDate().toISOString(),
       boxers: boxers.map((b) => {
         const base = {
           id: b.name,
@@ -74,6 +76,9 @@ export function applyLoadedState(state) {
   if (!state || !Array.isArray(state.boxers)) return;
   setPlayerBoxer(null);
   setMatchLog(state.matchLog || {});
+  if (state.currentDate) {
+    setCurrentDate(new Date(state.currentDate));
+  }
   state.boxers.forEach((saved) => {
     let boxer = BOXERS.find((b) => b.name === saved.id);
     if (!boxer && saved.userCreated) {
@@ -145,6 +150,7 @@ export function resetSavedData() {
   resetBoxers();
   setPlayerBoxer(null);
   resetMatchLog();
+  resetDate();
 }
 
 // Placeholder for future migration logic.


### PR DESCRIPTION
## Summary
- Track current game date globally and advance it one month after each completed round
- Display current date in ranking screen titles and schedule future matches based on this date
- Persist date in save data and age all boxers each January 1

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689bb3f11a3c832ab80df8575a269f35