### PR TITLE
Advance and persist calendar date after fights

### DIFF
--- a/src/scripts/calendar-scene.js
+++ b/src/scripts/calendar-scene.js
@@ -3,6 +3,7 @@ import {
   simulateMatch,
   getCurrentMatches,
   setCurrentMatches,
+  getLastParticipants,
 } from './calendar.js';
 import { getPendingMatch, clearPendingMatch } from './next-match.js';
 import { getMatchLog } from './match-log.js';
@@ -31,6 +32,7 @@ export class CalendarScene extends Phaser.Scene {
       this.matches = stored;
     } else {
       const { matches } = generateMonthlyMatches([
+        ...getLastParticipants(),
         pending.boxer1.name,
         pending.boxer2.name,
       ]);

--- a/src/scripts/calendar.js
+++ b/src/scripts/calendar.js
@@ -4,6 +4,7 @@ import { addMatchLog } from './match-log.js';
 import { getCurrentDate } from './game-date.js';
 
 let currentMatches = null;
+let lastParticipants = [];
 
 export function getCurrentMatches() {
   return currentMatches;
@@ -19,7 +20,21 @@ export function updateMatchResult(index, result) {
   }
 }
 
+export function getLastParticipants() {
+  return lastParticipants;
+}
+
 export function clearCurrentMatches() {
+  if (currentMatches) {
+    const names = new Set();
+    currentMatches.forEach((m) => {
+      if (m?.boxer1?.name) names.add(m.boxer1.name);
+      if (m?.boxer2?.name) names.add(m.boxer2.name);
+    });
+    lastParticipants = Array.from(names);
+  } else {
+    lastParticipants = [];
+  }
   currentMatches = null;
 }
 

--- a/src/scripts/game-result-scene.js
+++ b/src/scripts/game-result-scene.js
@@ -2,6 +2,8 @@ import { formatMoney, makeWhiteTransparent } from './helpers.js';
 import { SoundManager } from './sound-manager.js';
 import { updateMatchResult, clearCurrentMatches } from './calendar.js';
 import { advanceMonth } from './game-date.js';
+import { BOXERS } from './boxers.js';
+import { saveGameState } from './save-system.js';
 
 export class GameResultScene extends Phaser.Scene {
   constructor() {
@@ -117,6 +119,7 @@ export class GameResultScene extends Phaser.Scene {
       } else {
         clearCurrentMatches();
         advanceMonth();
+        saveGameState(BOXERS);
         this.scene.start('Ranking');
       }
     };


### PR DESCRIPTION
## Summary
- Track fighters who participated in the last month and exclude them when generating new matches
- Save game state after advancing the global date so the new month persists
- Use last participant list during calendar generation for fair scheduling

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689bb821ef38832ab7a36445f9d212c4