### PR TITLE
Add bank account tracking for boxers

### DIFF
--- a/src/scripts/boxer-stats.js
+++ b/src/scripts/boxer-stats.js
@@ -74,8 +74,12 @@ function awardEarnings(b1, b2, winner) {
   const purse = base * beltMult;
   const loserAmt = roundThousand(purse);
   const winnerAmt = winner ? roundThousand(purse * (1 + bonus)) : loserAmt;
-  b1.earnings = (b1.earnings || 0) + (winner === b1 ? winnerAmt : loserAmt);
-  b2.earnings = (b2.earnings || 0) + (winner === b2 ? winnerAmt : loserAmt);
+  const b1Prize = winner === b1 ? winnerAmt : loserAmt;
+  const b2Prize = winner === b2 ? winnerAmt : loserAmt;
+  b1.earnings = (b1.earnings || 0) + b1Prize;
+  b2.earnings = (b2.earnings || 0) + b2Prize;
+  b1.bank = (b1.bank || 0) + b1Prize;
+  b2.bank = (b2.bank || 0) + b2Prize;
 }
 
 // Record a win/loss result between two boxers.

--- a/src/scripts/boxers.js
+++ b/src/scripts/boxers.js
@@ -23,10 +23,14 @@ function initialEarnings(ranking) {
   return lerp(ranking, 81, 120, 10_000, 50_000);
 }
 
-const INIT_BOXERS = BOXER_DATA.map((b) => ({
-  ...b,
-  earnings: initialEarnings(b.ranking || 100),
-}));
+const INIT_BOXERS = BOXER_DATA.map((b) => {
+  const earn = initialEarnings(b.ranking || 100);
+  return {
+    ...b,
+    earnings: earn,
+    bank: earn,
+  };
+});
 
 // Mutable array of boxers used throughout the game.
 export const BOXERS = INIT_BOXERS.map((b) => ({ ...b }));

--- a/src/scripts/create-boxer-scene.js
+++ b/src/scripts/create-boxer-scene.js
@@ -103,7 +103,7 @@ export class CreateBoxerScene extends Phaser.Scene {
         stamina: state.stamina, power: state.power, health: state.health, speed: state.speed,
         ranking, matches: 0, wins: 0, losses: 0, draws: 0, winsByKO: 0,
         defaultStrategy: defaultStrategyForRanking(ranking),
-        ruleset: state.ruleset, userCreated: true, titles: [], earnings: 0
+        ruleset: state.ruleset, userCreated: true, titles: [], earnings: 0, bank: 0
       };
       addBoxer(boxer);
       setPlayerBoxer(boxer);

--- a/src/scripts/match-log-scene.js
+++ b/src/scripts/match-log-scene.js
@@ -26,6 +26,15 @@ export class MatchLogScene extends Phaser.Scene {
       })
       .setOrigin(0.5, 0);
 
+    if (boxer) {
+      this.add
+        .text(width / 2, 60, `Bank account balance: ${formatMoney(boxer.bank || 0)}`, {
+          font: '24px Arial',
+          color: '#ffffff',
+        })
+        .setOrigin(0.5, 0);
+    }
+
     this.log = getMatchLog(boxer?.name);
     this.expandedRows = new Set();
     const tableWidth = width * 0.95;

--- a/src/scripts/save-system.js
+++ b/src/scripts/save-system.js
@@ -43,6 +43,7 @@ export function saveGameState(boxers) {
           winsByKO: b.winsByKO,
           titles: b.titles || [],
           earnings: b.earnings || 0,
+          bank: b.bank || 0,
         };
         if (b.userCreated) {
           return {
@@ -59,6 +60,7 @@ export function saveGameState(boxers) {
             defaultStrategy: b.defaultStrategy,
             ruleset: b.ruleset,
             earnings: b.earnings || 0,
+            bank: b.bank || 0,
           };
         }
         return base;
@@ -105,6 +107,7 @@ export function applyLoadedState(state) {
         userCreated: true,
         titles: saved.titles ?? [],
         earnings: saved.earnings ?? 0,
+        bank: saved.bank ?? saved.earnings ?? 0,
       };
       addBoxer(boxer);
       setPlayerBoxer(boxer);
@@ -119,6 +122,7 @@ export function applyLoadedState(state) {
     boxer.winsByKO = saved.winsByKO ?? boxer.winsByKO;
     boxer.titles = saved.titles ?? boxer.titles ?? [];
     boxer.earnings = saved.earnings ?? boxer.earnings ?? 0;
+    boxer.bank = saved.bank ?? boxer.bank ?? boxer.earnings ?? 0;
     if (saved.userCreated) {
       boxer.userCreated = true;
       boxer.nickName = saved.nickName ?? boxer.nickName;


### PR DESCRIPTION
## Summary
- Track a bank balance for every boxer starting from their initial earnings
- Persist bank values when saving or loading game state
- Show current bank account balance above the match log table

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689bc0c74460832abbacc29c08f3450a