### PR TITLE
Track user boxer bank account via transactions

### DIFF
--- a/src/scripts/bank-account.js
+++ b/src/scripts/bank-account.js
@@ -1,0 +1,40 @@
+const BANK_KEY = 'theBoxer.bank.v1';
+
+function loadTransactions() {
+  if (typeof localStorage === 'undefined') return [];
+  try {
+    const raw = localStorage.getItem(BANK_KEY);
+    if (!raw) return [];
+    const data = JSON.parse(raw);
+    return Array.isArray(data) ? data : [];
+  } catch (err) {
+    return [];
+  }
+}
+
+function saveTransactions(txs) {
+  if (typeof localStorage === 'undefined') return;
+  try {
+    localStorage.setItem(BANK_KEY, JSON.stringify(txs));
+  } catch (err) {
+    // ignore
+  }
+}
+
+export function addTransaction(amount) {
+  const txs = loadTransactions();
+  txs.push(amount);
+  saveTransactions(txs);
+}
+
+export function getTransactions() {
+  return loadTransactions();
+}
+
+export function getBalance() {
+  return loadTransactions().reduce((sum, v) => sum + v, 0);
+}
+
+export function resetBankAccount() {
+  saveTransactions([]);
+}

--- a/src/scripts/boxer-stats.js
+++ b/src/scripts/boxer-stats.js
@@ -1,5 +1,7 @@
 import { BOXERS } from './boxers.js';
 import { TITLES } from './title-data.js';
+import { getPlayerBoxer } from './player-boxer.js';
+import { addTransaction } from './bank-account.js';
 
 const TITLE_MAP = TITLES.reduce((acc, t) => {
   acc[t.name] = t;
@@ -80,6 +82,9 @@ function awardEarnings(b1, b2, winner) {
   b2.earnings = (b2.earnings || 0) + b2Prize;
   b1.bank = (b1.bank || 0) + b1Prize;
   b2.bank = (b2.bank || 0) + b2Prize;
+  const player = getPlayerBoxer();
+  if (b1 === player) addTransaction(b1Prize);
+  if (b2 === player) addTransaction(b2Prize);
 }
 
 // Record a win/loss result between two boxers.

--- a/src/scripts/match-log-scene.js
+++ b/src/scripts/match-log-scene.js
@@ -3,6 +3,7 @@ import { SoundManager } from './sound-manager.js';
 import { getPlayerBoxer } from './player-boxer.js';
 import { tableAlpha } from './config.js';
 import { formatMoney } from './helpers.js';
+import { getBalance } from './bank-account.js';
 
 export class MatchLogScene extends Phaser.Scene {
   constructor() {
@@ -27,8 +28,10 @@ export class MatchLogScene extends Phaser.Scene {
       .setOrigin(0.5, 0);
 
     if (boxer) {
+      const balance =
+        boxer === getPlayerBoxer() ? getBalance() : boxer.bank || 0;
       this.add
-        .text(width / 2, 60, `Bank account balance: ${formatMoney(boxer.bank || 0)}`, {
+        .text(width / 2, 60, `Bank account balance: ${formatMoney(balance)}`, {
           font: '24px Arial',
           color: '#ffffff',
         })

--- a/src/scripts/player-boxer.js
+++ b/src/scripts/player-boxer.js
@@ -1,7 +1,12 @@
+import { getBalance } from './bank-account.js';
+
 let playerBoxer = null;
 
 export function setPlayerBoxer(boxer) {
   playerBoxer = boxer;
+  if (boxer) {
+    boxer.bank = getBalance();
+  }
 }
 
 export function getPlayerBoxer() {

--- a/src/scripts/save-system.js
+++ b/src/scripts/save-system.js
@@ -3,6 +3,7 @@ import { setPlayerBoxer } from './player-boxer.js';
 import { setMatchLog, resetMatchLog, getAllMatchLogs } from './match-log.js';
 import { SoundManager } from './sound-manager.js';
 import { getCurrentDate, setCurrentDate, resetDate } from './game-date.js';
+import { resetBankAccount } from './bank-account.js';
 
 const SAVE_KEY = 'theBoxer.save.v1';
 const VERSION = 1;
@@ -155,6 +156,7 @@ export function resetSavedData() {
   setPlayerBoxer(null);
   resetMatchLog();
   resetDate();
+  resetBankAccount();
 }
 
 // Placeholder for future migration logic.


### PR DESCRIPTION
## Summary
- add bank-account module to store income/expense transactions in localStorage
- sync player boxer bank with stored transactions and log prize money earnings
- show player bank balance from transactions in match log and reset bank data on full reset

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/theboxer/package.json')*

------
https://chatgpt.com/codex/tasks/task_e_689bc5a9b1f4832ab0ed184fa84685bb