### PR TITLE
Add basic perks system

### DIFF
--- a/src/scripts/boxer.js
+++ b/src/scripts/boxer.js
@@ -46,6 +46,7 @@ export class Boxer {
     this.health = this.maxHealth;
     this.defaultStrategy = stats.defaultStrategy || 1;
     this.userCreated = stats.userCreated || false;
+    this.perks = stats.perks || [];
     // slightly smaller boxer sprites
     this.sprite.setScale(350 / this.sprite.height);
     // boxer1 faces right, boxer2 faces left

--- a/src/scripts/boxers.js
+++ b/src/scripts/boxers.js
@@ -29,6 +29,7 @@ const INIT_BOXERS = BOXER_DATA.map((b) => {
     ...b,
     earnings: earn,
     bank: earn,
+    perks: [],
   };
 });
 

--- a/src/scripts/create-boxer-scene.js
+++ b/src/scripts/create-boxer-scene.js
@@ -103,7 +103,8 @@ export class CreateBoxerScene extends Phaser.Scene {
         stamina: state.stamina, power: state.power, health: state.health, speed: state.speed,
         ranking, matches: 0, wins: 0, losses: 0, draws: 0, winsByKO: 0,
         defaultStrategy: defaultStrategyForRanking(ranking),
-        ruleset: state.ruleset, userCreated: true, titles: [], earnings: 0, bank: 0
+        ruleset: state.ruleset, userCreated: true, titles: [], earnings: 0, bank: 0,
+        perks: [],
       };
       addBoxer(boxer);
       setPlayerBoxer(boxer);

--- a/src/scripts/main.js
+++ b/src/scripts/main.js
@@ -7,9 +7,11 @@ import { CreateBoxerScene } from './create-boxer-scene.js';
 import { MatchLogScene } from './match-log-scene.js';
 import { StartScene } from './start-scene.js';
 import { OptionsScene } from './options-scene.js';
+import { PerksScene } from './perks-scene.js';
 import { BackdropManager } from './backdrop-manager.js';
 import { MatchIntroScene } from './match-intro-scene.js';
 import { TITLES } from './title-data.js';
+import { PERKS } from './perks-data.js';
 import { GameResultScene } from './game-result-scene.js';
 import { CalendarScene } from './calendar-scene.js';
 
@@ -55,6 +57,13 @@ class BootScene extends Phaser.Scene {
     this.load.image('computer', 'assets/arena/computer.png');
     TITLES.forEach((t) => {
       this.load.image(t.name, `assets/titles/${t.name.toLowerCase()}.png`);
+    });
+    PERKS.forEach((p) => {
+      const key = `${p.Name.toLowerCase()}-level${p.Level}`;
+      this.load.image(
+        key,
+        `assets/Perks/${p.Name.toLowerCase()}-level${p.Level}.png`
+      );
     });
     // Load idle animation frames for the boxers
     for (let i = 0; i < 10; i++) {
@@ -166,6 +175,7 @@ const config = {
     StartScene,
     RankingScene,
     MatchLogScene,
+    PerksScene,
     CreateBoxerScene,
     OptionsScene,
     SelectBoxerScene,

--- a/src/scripts/match-log-scene.js
+++ b/src/scripts/match-log-scene.js
@@ -27,15 +27,40 @@ export class MatchLogScene extends Phaser.Scene {
       })
       .setOrigin(0.5, 0);
 
+    let headerY = 80;
     if (boxer) {
       const balance =
         boxer === getPlayerBoxer() ? getBalance() : boxer.bank || 0;
-      this.add
+      const balanceText = this.add
         .text(width / 2, 60, `Bank account balance: ${formatMoney(balance)}`, {
           font: '24px Arial',
           color: '#ffffff',
         })
         .setOrigin(0.5, 0);
+      if (boxer === getPlayerBoxer()) {
+        this.add
+          .text(
+            balanceText.x + balanceText.displayWidth / 2 + 20,
+            60,
+            'Buy Perks',
+            { font: '24px Arial', color: '#ffff00' }
+          )
+          .setOrigin(0, 0)
+          .setInteractive({ useHandCursor: true })
+          .on('pointerdown', () => {
+            this.scene.start('PerksScene');
+          });
+      }
+      if (boxer.perks && boxer.perks.length) {
+        const perksY = 100;
+        let x = width / 2 - (boxer.perks.length * 80) / 2;
+        boxer.perks.forEach((perk) => {
+          const key = `${perk.Name.toLowerCase()}-level${perk.Level}`;
+          this.add.image(x, perksY, key).setDisplaySize(64, 64);
+          x += 80;
+        });
+        headerY = perksY + 80;
+      }
     }
 
     this.log = getMatchLog(boxer?.name);
@@ -63,7 +88,6 @@ export class MatchLogScene extends Phaser.Scene {
       accum += p * tableWidth;
       return x;
     });
-    const headerY = 80;
     this.add
       .rectangle(width / 2, headerY, tableWidth, rowHeight, 0x001b44, tableAlpha)
       .setOrigin(0.5, 0);

--- a/src/scripts/perks-data.js
+++ b/src/scripts/perks-data.js
@@ -1,0 +1,5 @@
+export const PERKS = [
+  { "Name": "Strategy", "Level": 1, "Price": 20000 },
+  { "Name": "Strategy", "Level": 2, "Price": 50000 },
+  { "Name": "Strategy", "Level": 3, "Price": 50000 }
+];

--- a/src/scripts/perks-scene.js
+++ b/src/scripts/perks-scene.js
@@ -1,0 +1,89 @@
+import { PERKS } from './perks-data.js';
+import { getPlayerBoxer } from './player-boxer.js';
+import { addTransaction, getBalance } from './bank-account.js';
+import { formatMoney } from './helpers.js';
+import { SoundManager } from './sound-manager.js';
+import { saveGameState } from './save-system.js';
+import { BOXERS } from './boxers.js';
+
+export class PerksScene extends Phaser.Scene {
+  constructor() {
+    super('PerksScene');
+  }
+
+  create() {
+    const width = this.sys.game.config.width;
+    const height = this.sys.game.config.height;
+    SoundManager.playMenuLoop();
+    const player = getPlayerBoxer();
+
+    this.add
+      .text(width / 2, 20, 'Perks', {
+        font: '32px Arial',
+        color: '#ffffff',
+      })
+      .setOrigin(0.5, 0);
+
+    const balanceText = this.add
+      .text(
+        width / 2,
+        60,
+        `Bank account balance: ${formatMoney(getBalance())}`,
+        {
+          font: '24px Arial',
+          color: '#ffffff',
+        }
+      )
+      .setOrigin(0.5, 0);
+
+    const startY = 120;
+    const spacing = 120;
+    PERKS.forEach((perk, idx) => {
+      const y = startY + idx * spacing;
+      const key = `${perk.Name.toLowerCase()}-level${perk.Level}`;
+      this.add.image(width / 2 - 200, y, key).setDisplaySize(100, 100);
+      const label = `${perk.Name} Level ${perk.Level} - ${formatMoney(
+        perk.Price
+      )}`;
+      this.add.text(width / 2 - 100, y - 40, label, {
+        font: '24px Arial',
+        color: '#ffffff',
+      });
+      const owned = player?.perks?.some(
+        (p) => p.Name === perk.Name && p.Level === perk.Level
+      );
+      const btn = this.add
+        .text(width / 2 + 200, y, owned ? 'Owned' : 'Buy', {
+          font: '24px Arial',
+          color: '#ffff00',
+        })
+        .setOrigin(0.5, 0)
+        .setInteractive({ useHandCursor: true });
+      if (owned) {
+        btn.disableInteractive().setTint(0x888888);
+      } else {
+        btn.on('pointerdown', () => {
+          if (getBalance() < perk.Price) return;
+          player.perks.push({ ...perk });
+          addTransaction(-perk.Price);
+          player.bank = (player.bank || 0) - perk.Price;
+          saveGameState(BOXERS);
+          balanceText.setText(
+            `Bank account balance: ${formatMoney(getBalance())}`
+          );
+          btn.setText('Owned').disableInteractive().setTint(0x888888);
+        });
+      }
+    });
+
+    this.add
+      .text(20, height - 40, 'Back', {
+        font: '24px Arial',
+        color: '#ffff00',
+      })
+      .setInteractive({ useHandCursor: true })
+      .on('pointerdown', () => {
+        this.scene.start('MatchLog', { boxer: player });
+      });
+  }
+}

--- a/src/scripts/save-system.js
+++ b/src/scripts/save-system.js
@@ -45,6 +45,7 @@ export function saveGameState(boxers) {
           titles: b.titles || [],
           earnings: b.earnings || 0,
           bank: b.bank || 0,
+          perks: b.perks || [],
         };
         if (b.userCreated) {
           return {
@@ -62,6 +63,7 @@ export function saveGameState(boxers) {
             ruleset: b.ruleset,
             earnings: b.earnings || 0,
             bank: b.bank || 0,
+            perks: b.perks || [],
           };
         }
         return base;
@@ -109,6 +111,7 @@ export function applyLoadedState(state) {
         titles: saved.titles ?? [],
         earnings: saved.earnings ?? 0,
         bank: saved.bank ?? saved.earnings ?? 0,
+        perks: saved.perks ?? [],
       };
       addBoxer(boxer);
       setPlayerBoxer(boxer);
@@ -124,6 +127,7 @@ export function applyLoadedState(state) {
     boxer.titles = saved.titles ?? boxer.titles ?? [];
     boxer.earnings = saved.earnings ?? boxer.earnings ?? 0;
     boxer.bank = saved.bank ?? boxer.bank ?? boxer.earnings ?? 0;
+    boxer.perks = saved.perks ?? boxer.perks ?? [];
     if (saved.userCreated) {
       boxer.userCreated = true;
       boxer.nickName = saved.nickName ?? boxer.nickName;


### PR DESCRIPTION
## Summary
- add strategy perk data
- allow boxers to own perks and persist them in saves
- introduce Perks scene and integrate purchase button in match log

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689bd255f7f0832a857901167944abf9