### PR TITLE
Add text label to perk purchase button

### DIFF
--- a/src/scripts/match-log-scene.js
+++ b/src/scripts/match-log-scene.js
@@ -68,6 +68,14 @@ export class MatchLogScene extends Phaser.Scene {
           addBtn.add(
             this.add.image(0, 0, 'perk_add').setDisplaySize(54, 54)
           );
+          addBtn.add(
+            this.add
+              .text(-50, 0, 'Buy perks', {
+                font: '20px Arial',
+                color: '#ffff00',
+              })
+              .setOrigin(1, 0.5)
+          );
           addBtn.setSize(64, 64);
           addBtn
             .setInteractive({ useHandCursor: true })
@@ -84,6 +92,14 @@ export class MatchLogScene extends Phaser.Scene {
         );
         addBtn.add(
           this.add.image(0, 0, 'perk_add').setDisplaySize(54, 54)
+        );
+        addBtn.add(
+          this.add
+            .text(-50, 0, 'Buy perks', {
+              font: '20px Arial',
+              color: '#ffff00',
+            })
+            .setOrigin(1, 0.5)
         );
         addBtn.setSize(64, 64);
         addBtn


### PR DESCRIPTION
## Summary
- Show a "Buy perks" label next to the add-perk icon so players know the button's purpose

## Testing
- `npm test` (fails: ENOENT, no package.json)


------
https://chatgpt.com/codex/tasks/task_e_689c49bf36b0832a9207c68208a28cfb