### PR TITLE
Restrict strategy options by perk level and enforce perk progression

### DIFF
--- a/src/scripts/match-scene.js
+++ b/src/scripts/match-scene.js
@@ -1,5 +1,6 @@
 import { Boxer } from './boxer.js';
 import { StrategyAIController } from './strategy-ai-controller.js';
+import { getMaxStrategyLevel } from './player-boxer.js';
 import { KeyboardController } from './controllers.js';
 import { createBoxerAnimations } from './animation-factory.js';
 import { eventBus } from './event-bus.js';
@@ -44,13 +45,13 @@ export class MatchScene extends Phaser.Scene {
     createBoxerAnimations(this, BOXER_PREFIXES.P2);
 
     // Player 1 may be human or AI controlled; player 2 always AI
+    let level1 = data.boxer1?.defaultStrategy || 1;
+    if (data.aiLevel1 && data.aiLevel1 !== 'default') {
+      level1 = parseInt(data.aiLevel1, 10) || level1;
+    }
+    level1 = Math.min(level1, getMaxStrategyLevel(data.boxer1));
     const controller1 = data?.aiLevel1
-      ? new StrategyAIController(
-          data.aiLevel1 === 'default'
-            ? data.boxer1?.defaultStrategy || 1
-            : data.aiLevel1,
-          1
-        )
+      ? new StrategyAIController(level1, 1)
       : new KeyboardController(this, {
           block: 'S',
           jabRight: 'E',

--- a/src/scripts/overlay.js
+++ b/src/scripts/overlay.js
@@ -2,6 +2,7 @@ import { eventBus } from './event-bus.js';
 import { appConfig } from './config.js';
 import { SoundManager } from './sound-manager.js';
 import { createStrategyLevelSelector } from './UIDialogControls.js';
+import { getMaxStrategyLevel } from './player-boxer.js';
 
 export class OverlayUI extends Phaser.Scene {
   constructor() {
@@ -368,7 +369,7 @@ export class OverlayUI extends Phaser.Scene {
     this.nextRoundHandler = () => this.triggerNextRound();
     this.input.once('pointerup', this.nextRoundHandler);
     if (match?.isP1AI) {
-      this.showStrategyOptions(10);
+      this.showStrategyOptions(getMaxStrategyLevel(match.player1));
     }
   }
 
@@ -393,6 +394,7 @@ export class OverlayUI extends Phaser.Scene {
   showStrategyOptions(maxLevel = 10, locked = false) {
     const match = this.scene.get('MatchScene');
     if (!match) return;
+    maxLevel = Math.min(maxLevel, getMaxStrategyLevel(match.player1));
     const controller = match.player1?.controller;
     if (!controller || typeof controller.getLevel !== 'function') return;
     const defaultLevel = match.player1.stats?.defaultStrategy || 1;
@@ -422,7 +424,7 @@ export class OverlayUI extends Phaser.Scene {
       y: centerY,
       onSelect: (level) => {
         if (level === 'default') {
-          controller.setLevel(defaultLevel);
+          controller.setLevel(Math.min(defaultLevel, maxLevel));
         } else {
           controller.setLevel(parseInt(level, 10));
         }

--- a/src/scripts/perks-scene.js
+++ b/src/scripts/perks-scene.js
@@ -52,18 +52,34 @@ export class PerksScene extends Phaser.Scene {
       const owned = player?.perks?.some(
         (p) => p.Name === perk.Name && p.Level === perk.Level
       );
+      const prevOwned =
+        perk.Level === 1 ||
+        player?.perks?.some(
+          (p) => p.Name === perk.Name && p.Level === perk.Level - 1
+        );
       const btn = this.add
-        .text(width / 2 + 200, y, owned ? 'Owned' : 'Buy', {
-          font: '24px Arial',
-          color: '#ffff00',
-        })
+        .text(
+          width / 2 + 200,
+          y,
+          owned ? 'Owned' : prevOwned ? 'Buy' : 'Locked',
+          {
+            font: '24px Arial',
+            color: '#ffff00',
+          }
+        )
         .setOrigin(0.5, 0)
         .setInteractive({ useHandCursor: true });
-      if (owned) {
+      if (owned || !prevOwned) {
         btn.disableInteractive().setTint(0x888888);
       } else {
         btn.on('pointerdown', () => {
           if (getBalance() < perk.Price) return;
+          const prereq =
+            perk.Level === 1 ||
+            player.perks.some(
+              (p) => p.Name === perk.Name && p.Level === perk.Level - 1
+            );
+          if (!prereq) return;
           player.perks.push({ ...perk });
           addTransaction(-perk.Price);
           player.bank = (player.bank || 0) - perk.Price;

--- a/src/scripts/player-boxer.js
+++ b/src/scripts/player-boxer.js
@@ -12,3 +12,18 @@ export function setPlayerBoxer(boxer) {
 export function getPlayerBoxer() {
   return playerBoxer;
 }
+
+export function getStrategyPerkLevel(boxer = playerBoxer) {
+  if (!boxer?.perks) return 0;
+  return boxer.perks
+    .filter((p) => p.Name === 'Strategy')
+    .reduce((max, p) => Math.max(max, p.Level), 0);
+}
+
+export function getMaxStrategyLevel(boxer = playerBoxer) {
+  const lvl = getStrategyPerkLevel(boxer);
+  if (lvl >= 3) return 10;
+  if (lvl === 2) return 6;
+  if (lvl === 1) return 3;
+  return 1;
+}

--- a/src/scripts/select-boxer-scene.js
+++ b/src/scripts/select-boxer-scene.js
@@ -1,6 +1,6 @@
 import { getRankings, getMatchPreview } from './boxer-stats.js';
 import { getTestMode, tableAlpha } from './config.js';
-import { getPlayerBoxer } from './player-boxer.js';
+import { getPlayerBoxer, getMaxStrategyLevel } from './player-boxer.js';
 import { SoundManager } from './sound-manager.js';
 import { scheduleMatch, getPendingMatch } from './next-match.js';
 import { createStrategyLevelSelector, createRoundSelector } from './UIDialogControls.js';
@@ -264,7 +264,7 @@ export class SelectBoxerScene extends Phaser.Scene {
     } else {
       this.step = 1;
       this.instruction.setText('Choose Player 1 strategy');
-      this.showStrategyOptions(10);
+      this.showStrategyOptions(getMaxStrategyLevel());
     }
   }
 


### PR DESCRIPTION
## Summary
- limit strategy selection to levels allowed by purchased Strategy perks
- clamp default and selected strategies during matches to perk-based caps
- require Strategy perks to be bought sequentially

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689c51ac1454832aa058f11873e718b9