### PR TITLE
Allow perk usage without restrictions in test mode

### DIFF
--- a/src/scripts/player-boxer.js
+++ b/src/scripts/player-boxer.js
@@ -1,4 +1,5 @@
 import { getBalance } from './bank-account.js';
+import { getTestMode } from './config.js';
 
 let playerBoxer = null;
 
@@ -21,6 +22,7 @@ export function getStrategyPerkLevel(boxer = playerBoxer) {
 }
 
 export function getMaxStrategyLevel(boxer = playerBoxer) {
+  if (getTestMode()) return 10;
   const lvl = getStrategyPerkLevel(boxer);
   if (lvl >= 3) return 10;
   if (lvl === 2) return 6;


### PR DESCRIPTION
## Summary
- Remove perk purchase restrictions when TestMode is enabled
- Allow maximum strategy level for the player in TestMode

## Testing
- `npm test` *(fails: no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689c55f410d8832ab7a73318117584d0