### PR TITLE
Add Change perk to enable strategy adjustments

### DIFF
--- a/src/scripts/overlay.js
+++ b/src/scripts/overlay.js
@@ -1,8 +1,8 @@
 import { eventBus } from './event-bus.js';
-import { appConfig } from './config.js';
+import { appConfig, getTestMode } from './config.js';
 import { SoundManager } from './sound-manager.js';
 import { createStrategyLevelSelector } from './UIDialogControls.js';
-import { getMaxStrategyLevel } from './player-boxer.js';
+import { getMaxStrategyLevel, hasChangePerk } from './player-boxer.js';
 
 export class OverlayUI extends Phaser.Scene {
   constructor() {
@@ -369,7 +369,8 @@ export class OverlayUI extends Phaser.Scene {
     this.nextRoundHandler = () => this.triggerNextRound();
     this.input.once('pointerup', this.nextRoundHandler);
     if (match?.isP1AI) {
-      this.showStrategyOptions(getMaxStrategyLevel(match.player1));
+      const locked = !getTestMode() && !hasChangePerk(match.player1);
+      this.showStrategyOptions(getMaxStrategyLevel(match.player1), locked);
     }
   }
 

--- a/src/scripts/perks-data.js
+++ b/src/scripts/perks-data.js
@@ -1,5 +1,6 @@
 export const PERKS = [
   { "Name": "Strategy", "Level": 1, "Price": 20000 },
   { "Name": "Strategy", "Level": 2, "Price": 50000 },
-  { "Name": "Strategy", "Level": 3, "Price": 50000 }
+  { "Name": "Strategy", "Level": 3, "Price": 50000 },
+  { "Name": "Change", "Level": 1, "Price": 100000 }
 ];

--- a/src/scripts/player-boxer.js
+++ b/src/scripts/player-boxer.js
@@ -29,3 +29,8 @@ export function getMaxStrategyLevel(boxer = playerBoxer) {
   if (lvl === 1) return 3;
   return 1;
 }
+
+export function hasChangePerk(boxer = playerBoxer) {
+  if (!boxer?.perks) return false;
+  return boxer.perks.some((p) => p.Name === 'Change');
+}


### PR DESCRIPTION
## Summary
- Add Change perk data and pricing
- Detect Change perk to unlock strategy adjustments in round breaks
- Guard strategy change by Change perk or Test Mode

## Testing
- ⚠️ `npm test` *(missing package.json, tests not run)*

------
https://chatgpt.com/codex/tasks/task_e_689c59f9c974832ab38e5f2208bf828c