### PR TITLE
Refactor strategy to playbook terminology

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 A small boxing game built with Phaser. Two boxers are displayed in the ring.
 Each boxer is controlled by a controller object. When the game starts you first
 select the boxer you will control with the keyboard, then choose an opponent
-that is steered by the computer along with its opening strategy. After picking
-a strategy you will be shown a summary of the match setup where you can confirm
+that is steered by the computer along with its opening playbook. After picking
+a playbook you will be shown a summary of the match setup where you can confirm
 or cancel your choices. Because the behaviour is abstracted through controllers
 it is trivial to swap a boxer to a different type of controller in the future.
 

--- a/src/scripts/UIDialogControls.js
+++ b/src/scripts/UIDialogControls.js
@@ -1,4 +1,4 @@
-export function createStrategyLevelSelector(
+export function createPlaybookLevelSelector(
   scene,
   {
     maxLevel = 10,
@@ -23,12 +23,12 @@ export function createStrategyLevelSelector(
   const panelHTML = `
     <div style="background:rgba(0,0,0,0.6);padding:16px 18px;text-align:center;border-radius:10px;color:#fff;min-width:360px;font-family:Arial,sans-serif;">
       <div style="font-size:18px;margin-bottom:8px;">
-        Strategy level: <span id="strategy-value" style="color:#fff;">${startVal}</span>
+        Playbook level: <span id="playbook-value" style="color:#fff;">${startVal}</span>
       </div>
-      <input id="strategy-slider" type="range" min="1" max="${cap}" step="1" value="${startVal}" style="width:320px;margin-bottom:12px;" ${locked ? 'disabled' : ''}>
+      <input id="playbook-slider" type="range" min="1" max="${cap}" step="1" value="${startVal}" style="width:320px;margin-bottom:12px;" ${locked ? 'disabled' : ''}>
       <div style="display:flex;gap:12px;justify-content:center;">
-        ${locked ? '' : `<button id="strategy-default" type="button" style="padding:6px 12px;">${defaultLabel}</button>`}
-        <button id="strategy-select" type="button" style="padding:6px 12px;">${selectLabel}</button>
+        ${locked ? '' : `<button id="playbook-default" type="button" style="padding:6px 12px;">${defaultLabel}</button>`}
+        <button id="playbook-select" type="button" style="padding:6px 12px;">${selectLabel}</button>
       </div>
     </div>
   `;
@@ -36,10 +36,10 @@ export function createStrategyLevelSelector(
   const dom = scene.add.dom(posX, posY).createFromHTML(panelHTML);
   dom.setOrigin(0.5);
 
-  const slider = dom.getChildByID('strategy-slider');
-  const valueLabel = dom.getChildByID('strategy-value');
-  const selectBtn = dom.getChildByID('strategy-select');
-  const defaultBtn = dom.getChildByID('strategy-default');
+  const slider = dom.getChildByID('playbook-slider');
+  const valueLabel = dom.getChildByID('playbook-value');
+  const selectBtn = dom.getChildByID('playbook-select');
+  const defaultBtn = dom.getChildByID('playbook-default');
 
   slider.min = '1';
   slider.max = String(cap);

--- a/src/scripts/ai-playbooks.js
+++ b/src/scripts/ai-playbooks.js
@@ -1,4 +1,4 @@
-// Precomputed AI strategies for 10 offensive levels
+// Precomputed AI playbooks for 10 offensive levels
 
 function baseActions() {
   return {
@@ -21,7 +21,7 @@ function baseActions() {
   };
 }
 
-function generateStrategy(level) {
+function generatePlaybook(level) {
   const forwardProb = Math.min(0.1 + 0.05 * level, 0.8);
   const backProb = Math.max(0.6 - 0.05 * level, 0.05);
   const blockProb = Math.max(0.7 - 0.05 * level, 0.1);
@@ -59,13 +59,13 @@ function generateStrategy(level) {
   return actions;
 }
 
-// Separate strategy sets for each boxer so identical levels don't share actions
-export const STRATEGIES_P1 = Array.from({ length: 10 }, (_, i) => ({
-  actions: generateStrategy(i + 1),
+// Separate playbook sets for each boxer so identical levels don't share actions
+export const PLAYBOOKS_P1 = Array.from({ length: 10 }, (_, i) => ({
+  actions: generatePlaybook(i + 1),
 }));
 
-export const STRATEGIES_P2 = Array.from({ length: 10 }, (_, i) => ({
-  actions: generateStrategy(i + 1),
+export const PLAYBOOKS_P2 = Array.from({ length: 10 }, (_, i) => ({
+  actions: generatePlaybook(i + 1),
 }));
 
 export function createBaseActions() {

--- a/src/scripts/boxer-data.js
+++ b/src/scripts/boxer-data.js
@@ -16,7 +16,7 @@ export const BOXER_DATA = [
     "age": 29,
     "ruleset": 1,
     "ranking": 100,
-    "defaultStrategy": 4
+    "defaultPlaybook": 4
   },
   {
     "name": "Von Kaiser",
@@ -35,7 +35,7 @@ export const BOXER_DATA = [
     "age": 36,
     "ruleset": 1,
     "ranking": 99,
-    "defaultStrategy": 3
+    "defaultPlaybook": 3
   },
   {
     "name": "Ty Nixon",
@@ -53,7 +53,7 @@ export const BOXER_DATA = [
     "draws": 3,
     "winsByKO": 7,
     "age": 26,
-    "defaultStrategy": 1,
+    "defaultPlaybook": 1,
     "ruleset": 1
   },
   {
@@ -72,7 +72,7 @@ export const BOXER_DATA = [
     "draws": 1,
     "winsByKO": 4,
     "age": 37,
-    "defaultStrategy": 1,
+    "defaultPlaybook": 1,
     "ruleset": 3
   },
   {
@@ -91,7 +91,7 @@ export const BOXER_DATA = [
     "draws": 2,
     "winsByKO": 13,
     "age": 24,
-    "defaultStrategy": 3,
+    "defaultPlaybook": 3,
     "ruleset": 3
   },
   {
@@ -110,7 +110,7 @@ export const BOXER_DATA = [
     "draws": 2,
     "winsByKO": 1,
     "age": 32,
-    "defaultStrategy": 3,
+    "defaultPlaybook": 3,
     "ruleset": 2
   },
   {
@@ -129,7 +129,7 @@ export const BOXER_DATA = [
     "draws": 0,
     "winsByKO": 7,
     "age": 38,
-    "defaultStrategy": 4,
+    "defaultPlaybook": 4,
     "ruleset": 1
   },
   {
@@ -148,7 +148,7 @@ export const BOXER_DATA = [
     "draws": 3,
     "winsByKO": 8,
     "age": 28,
-    "defaultStrategy": 1,
+    "defaultPlaybook": 1,
     "ruleset": 2
   },
   {
@@ -167,7 +167,7 @@ export const BOXER_DATA = [
     "draws": 2,
     "winsByKO": 11,
     "age": 36,
-    "defaultStrategy": 3,
+    "defaultPlaybook": 3,
     "ruleset": 3
   },
   {
@@ -186,7 +186,7 @@ export const BOXER_DATA = [
     "draws": 0,
     "winsByKO": 7,
     "age": 35,
-    "defaultStrategy": 2,
+    "defaultPlaybook": 2,
     "ruleset": 2
   },
   {
@@ -205,7 +205,7 @@ export const BOXER_DATA = [
     "draws": 2,
     "winsByKO": 6,
     "age": 20,
-    "defaultStrategy": 1,
+    "defaultPlaybook": 1,
     "ruleset": 3
   },
   {
@@ -224,7 +224,7 @@ export const BOXER_DATA = [
     "draws": 3,
     "winsByKO": 12,
     "age": 26,
-    "defaultStrategy": 1,
+    "defaultPlaybook": 1,
     "ruleset": 1
   },
   {
@@ -243,7 +243,7 @@ export const BOXER_DATA = [
     "draws": 2,
     "winsByKO": 8,
     "age": 18,
-    "defaultStrategy": 4,
+    "defaultPlaybook": 4,
     "ruleset": 1
   },
   {
@@ -262,7 +262,7 @@ export const BOXER_DATA = [
     "draws": 2,
     "winsByKO": 1,
     "age": 21,
-    "defaultStrategy": 3,
+    "defaultPlaybook": 3,
     "ruleset": 2
   },
   {
@@ -281,7 +281,7 @@ export const BOXER_DATA = [
     "draws": 2,
     "winsByKO": 1,
     "age": 22,
-    "defaultStrategy": 2,
+    "defaultPlaybook": 2,
     "ruleset": 2
   },
   {
@@ -300,7 +300,7 @@ export const BOXER_DATA = [
     "draws": 2,
     "winsByKO": 4,
     "age": 24,
-    "defaultStrategy": 2,
+    "defaultPlaybook": 2,
     "ruleset": 1
   },
   {
@@ -319,7 +319,7 @@ export const BOXER_DATA = [
     "draws": 3,
     "winsByKO": 12,
     "age": 37,
-    "defaultStrategy": 1,
+    "defaultPlaybook": 1,
     "ruleset": 1
   },
   {
@@ -338,7 +338,7 @@ export const BOXER_DATA = [
     "draws": 2,
     "winsByKO": 3,
     "age": 29,
-    "defaultStrategy": 4,
+    "defaultPlaybook": 4,
     "ruleset": 2
   },
   {
@@ -357,7 +357,7 @@ export const BOXER_DATA = [
     "draws": 0,
     "winsByKO": 6,
     "age": 30,
-    "defaultStrategy": 4,
+    "defaultPlaybook": 4,
     "ruleset": 3
   },
   {
@@ -376,7 +376,7 @@ export const BOXER_DATA = [
     "draws": 2,
     "winsByKO": 9,
     "age": 18,
-    "defaultStrategy": 3,
+    "defaultPlaybook": 3,
     "ruleset": 3
   },
   {
@@ -395,7 +395,7 @@ export const BOXER_DATA = [
     "draws": 2,
     "winsByKO": 7,
     "age": 36,
-    "defaultStrategy": 4,
+    "defaultPlaybook": 4,
     "ruleset": 2
   },
   {
@@ -414,7 +414,7 @@ export const BOXER_DATA = [
     "draws": 1,
     "winsByKO": 3,
     "age": 28,
-    "defaultStrategy": 4,
+    "defaultPlaybook": 4,
     "ruleset": 3
   },
   {
@@ -433,7 +433,7 @@ export const BOXER_DATA = [
     "draws": 1,
     "winsByKO": 3,
     "age": 24,
-    "defaultStrategy": 4,
+    "defaultPlaybook": 4,
     "ruleset": 1
   },
   {
@@ -452,7 +452,7 @@ export const BOXER_DATA = [
     "draws": 0,
     "winsByKO": 4,
     "age": 39,
-    "defaultStrategy": 4,
+    "defaultPlaybook": 4,
     "ruleset": 2
   },
   {
@@ -471,7 +471,7 @@ export const BOXER_DATA = [
     "draws": 1,
     "winsByKO": 4,
     "age": 29,
-    "defaultStrategy": 3,
+    "defaultPlaybook": 3,
     "ruleset": 1
   },
   {
@@ -490,7 +490,7 @@ export const BOXER_DATA = [
     "draws": 2,
     "winsByKO": 3,
     "age": 32,
-    "defaultStrategy": 2,
+    "defaultPlaybook": 2,
     "ruleset": 3
   },
   {
@@ -509,7 +509,7 @@ export const BOXER_DATA = [
     "draws": 0,
     "winsByKO": 1,
     "age": 34,
-    "defaultStrategy": 3,
+    "defaultPlaybook": 3,
     "ruleset": 3
   },
   {
@@ -528,7 +528,7 @@ export const BOXER_DATA = [
     "draws": 3,
     "winsByKO": 5,
     "age": 34,
-    "defaultStrategy": 4,
+    "defaultPlaybook": 4,
     "ruleset": 3
   },
   {
@@ -547,7 +547,7 @@ export const BOXER_DATA = [
     "draws": 0,
     "winsByKO": 5,
     "age": 24,
-    "defaultStrategy": 4,
+    "defaultPlaybook": 4,
     "ruleset": 3
   },
   {
@@ -566,7 +566,7 @@ export const BOXER_DATA = [
     "draws": 0,
     "winsByKO": 14,
     "age": 40,
-    "defaultStrategy": 2,
+    "defaultPlaybook": 2,
     "ruleset": 1
   },
   {
@@ -586,7 +586,7 @@ export const BOXER_DATA = [
     "age": 23,
     "ruleset": 1,
     "ranking": 70,
-    "defaultStrategy": 2
+    "defaultPlaybook": 2
   },
   {
     "name": "Owen Young",
@@ -604,7 +604,7 @@ export const BOXER_DATA = [
     "draws": 1,
     "winsByKO": 8,
     "age": 26,
-    "defaultStrategy": 4,
+    "defaultPlaybook": 4,
     "ruleset": 2
   },
   {
@@ -623,7 +623,7 @@ export const BOXER_DATA = [
     "draws": 2,
     "winsByKO": 8,
     "age": 22,
-    "defaultStrategy": 4,
+    "defaultPlaybook": 4,
     "ruleset": 3
   },
   {
@@ -642,7 +642,7 @@ export const BOXER_DATA = [
     "draws": 2,
     "winsByKO": 3,
     "age": 36,
-    "defaultStrategy": 3,
+    "defaultPlaybook": 3,
     "ruleset": 1
   },
   {
@@ -661,7 +661,7 @@ export const BOXER_DATA = [
     "draws": 0,
     "winsByKO": 6,
     "age": 24,
-    "defaultStrategy": 4,
+    "defaultPlaybook": 4,
     "ruleset": 1
   },
   {
@@ -680,7 +680,7 @@ export const BOXER_DATA = [
     "draws": 2,
     "winsByKO": 4,
     "age": 31,
-    "defaultStrategy": 2,
+    "defaultPlaybook": 2,
     "ruleset": 3
   },
   {
@@ -699,7 +699,7 @@ export const BOXER_DATA = [
     "draws": 3,
     "winsByKO": 5,
     "age": 22,
-    "defaultStrategy": 3,
+    "defaultPlaybook": 3,
     "ruleset": 1
   },
   {
@@ -718,7 +718,7 @@ export const BOXER_DATA = [
     "draws": 0,
     "winsByKO": 6,
     "age": 36,
-    "defaultStrategy": 4,
+    "defaultPlaybook": 4,
     "ruleset": 1
   },
   {
@@ -737,7 +737,7 @@ export const BOXER_DATA = [
     "draws": 3,
     "winsByKO": 7,
     "age": 22,
-    "defaultStrategy": 4,
+    "defaultPlaybook": 4,
     "ruleset": 2
   },
   {
@@ -756,7 +756,7 @@ export const BOXER_DATA = [
     "draws": 0,
     "winsByKO": 13,
     "age": 20,
-    "defaultStrategy": 4,
+    "defaultPlaybook": 4,
     "ruleset": 3
   },
   {
@@ -776,7 +776,7 @@ export const BOXER_DATA = [
     "age": 27,
     "ruleset": 2,
     "ranking": 60,
-    "defaultStrategy": 3
+    "defaultPlaybook": 3
   },
   {
     "name": "Ty Johnson",
@@ -794,7 +794,7 @@ export const BOXER_DATA = [
     "draws": 3,
     "winsByKO": 7,
     "age": 22,
-    "defaultStrategy": 4,
+    "defaultPlaybook": 4,
     "ruleset": 3
   },
   {
@@ -813,7 +813,7 @@ export const BOXER_DATA = [
     "draws": 1,
     "winsByKO": 13,
     "age": 30,
-    "defaultStrategy": 2,
+    "defaultPlaybook": 2,
     "ruleset": 1
   },
   {
@@ -832,7 +832,7 @@ export const BOXER_DATA = [
     "draws": 3,
     "winsByKO": 5,
     "age": 34,
-    "defaultStrategy": 4,
+    "defaultPlaybook": 4,
     "ruleset": 3
   },
   {
@@ -851,7 +851,7 @@ export const BOXER_DATA = [
     "draws": 2,
     "winsByKO": 3,
     "age": 23,
-    "defaultStrategy": 3,
+    "defaultPlaybook": 3,
     "ruleset": 1
   },
   {
@@ -870,7 +870,7 @@ export const BOXER_DATA = [
     "draws": 1,
     "winsByKO": 12,
     "age": 24,
-    "defaultStrategy": 3,
+    "defaultPlaybook": 3,
     "ruleset": 1
   },
   {
@@ -889,7 +889,7 @@ export const BOXER_DATA = [
     "draws": 0,
     "winsByKO": 16,
     "age": 22,
-    "defaultStrategy": 4,
+    "defaultPlaybook": 4,
     "ruleset": 3
   },
   {
@@ -908,7 +908,7 @@ export const BOXER_DATA = [
     "draws": 1,
     "winsByKO": 10,
     "age": 30,
-    "defaultStrategy": 2,
+    "defaultPlaybook": 2,
     "ruleset": 2
   },
   {
@@ -927,7 +927,7 @@ export const BOXER_DATA = [
     "draws": 3,
     "winsByKO": 8,
     "age": 27,
-    "defaultStrategy": 4,
+    "defaultPlaybook": 4,
     "ruleset": 2
   },
   {
@@ -946,7 +946,7 @@ export const BOXER_DATA = [
     "draws": 3,
     "winsByKO": 9,
     "age": 37,
-    "defaultStrategy": 2,
+    "defaultPlaybook": 2,
     "ruleset": 3
   },
   {
@@ -966,7 +966,7 @@ export const BOXER_DATA = [
     "age": 21,
     "ruleset": 2,
     "ranking": 50,
-    "defaultStrategy": 2
+    "defaultPlaybook": 2
   },
   {
     "name": "Pete Vargas",
@@ -984,7 +984,7 @@ export const BOXER_DATA = [
     "draws": 3,
     "winsByKO": 5,
     "age": 21,
-    "defaultStrategy": 4,
+    "defaultPlaybook": 4,
     "ruleset": 2
   },
   {
@@ -1003,7 +1003,7 @@ export const BOXER_DATA = [
     "draws": 0,
     "winsByKO": 10,
     "age": 37,
-    "defaultStrategy": 3,
+    "defaultPlaybook": 3,
     "ruleset": 3,
     "titles": ["EBU"]
   },
@@ -1023,7 +1023,7 @@ export const BOXER_DATA = [
     "draws": 0,
     "winsByKO": 9,
     "age": 23,
-    "defaultStrategy": 4,
+    "defaultPlaybook": 4,
     "ruleset": 3
   },
   {
@@ -1042,7 +1042,7 @@ export const BOXER_DATA = [
     "draws": 1,
     "winsByKO": 10,
     "age": 24,
-    "defaultStrategy": 3,
+    "defaultPlaybook": 3,
     "ruleset": 1
   },
   {
@@ -1061,7 +1061,7 @@ export const BOXER_DATA = [
     "draws": 3,
     "winsByKO": 10,
     "age": 34,
-    "defaultStrategy": 3,
+    "defaultPlaybook": 3,
     "ruleset": 3
   },
   {
@@ -1080,7 +1080,7 @@ export const BOXER_DATA = [
     "draws": 1,
     "winsByKO": 8,
     "age": 18,
-    "defaultStrategy": 6,
+    "defaultPlaybook": 6,
     "ruleset": 2
   },
   {
@@ -1099,7 +1099,7 @@ export const BOXER_DATA = [
     "draws": 3,
     "winsByKO": 16,
     "age": 23,
-    "defaultStrategy": 4,
+    "defaultPlaybook": 4,
     "ruleset": 1
   },
   {
@@ -1118,7 +1118,7 @@ export const BOXER_DATA = [
     "draws": 2,
     "winsByKO": 4,
     "age": 19,
-    "defaultStrategy": 6,
+    "defaultPlaybook": 6,
     "ruleset": 2
   },
   {
@@ -1137,7 +1137,7 @@ export const BOXER_DATA = [
     "draws": 2,
     "winsByKO": 10,
     "age": 22,
-    "defaultStrategy": 5,
+    "defaultPlaybook": 5,
     "ruleset": 1,
     "titles": ["OPBF"]
   },
@@ -1158,7 +1158,7 @@ export const BOXER_DATA = [
     "age": 32,
     "ruleset": 3,
     "ranking": 40,
-    "defaultStrategy": 4
+    "defaultPlaybook": 4
   },
   {
     "name": "Yosef Evans",
@@ -1176,7 +1176,7 @@ export const BOXER_DATA = [
     "draws": 2,
     "winsByKO": 2,
     "age": 19,
-    "defaultStrategy": 6,
+    "defaultPlaybook": 6,
     "ruleset": 2
   },
   {
@@ -1195,7 +1195,7 @@ export const BOXER_DATA = [
     "draws": 2,
     "winsByKO": 7,
     "age": 37,
-    "defaultStrategy": 5,
+    "defaultPlaybook": 5,
     "ruleset": 2
   },
   {
@@ -1214,7 +1214,7 @@ export const BOXER_DATA = [
     "draws": 3,
     "winsByKO": 12,
     "age": 22,
-    "defaultStrategy": 5,
+    "defaultPlaybook": 5,
     "ruleset": 3
   },
   {
@@ -1233,7 +1233,7 @@ export const BOXER_DATA = [
     "draws": 3,
     "winsByKO": 3,
     "age": 22,
-    "defaultStrategy": 5,
+    "defaultPlaybook": 5,
     "ruleset": 3
   },
   {
@@ -1252,7 +1252,7 @@ export const BOXER_DATA = [
     "draws": 3,
     "winsByKO": 7,
     "age": 27,
-    "defaultStrategy": 5,
+    "defaultPlaybook": 5,
     "ruleset": 2
   },
   {
@@ -1271,7 +1271,7 @@ export const BOXER_DATA = [
     "draws": 3,
     "winsByKO": 3,
     "age": 39,
-    "defaultStrategy": 5,
+    "defaultPlaybook": 5,
     "ruleset": 2
   },
   {
@@ -1290,7 +1290,7 @@ export const BOXER_DATA = [
     "draws": 2,
     "winsByKO": 4,
     "age": 37,
-    "defaultStrategy": 6,
+    "defaultPlaybook": 6,
     "ruleset": 3
   },
   {
@@ -1309,7 +1309,7 @@ export const BOXER_DATA = [
     "draws": 1,
     "winsByKO": 3,
     "age": 23,
-    "defaultStrategy": 5,
+    "defaultPlaybook": 5,
     "ruleset": 3,
     "titles": ["SABC"]
   },
@@ -1329,7 +1329,7 @@ export const BOXER_DATA = [
     "draws": 1,
     "winsByKO": 9,
     "age": 24,
-    "defaultStrategy": 6,
+    "defaultPlaybook": 6,
     "ruleset": 2
   },
   {
@@ -1349,7 +1349,7 @@ export const BOXER_DATA = [
     "age": 27,
     "ruleset": 2,
     "ranking": 30,
-    "defaultStrategy": 5
+    "defaultPlaybook": 5
   },
   {
     "name": "Frank Irving",
@@ -1367,7 +1367,7 @@ export const BOXER_DATA = [
     "draws": 3,
     "winsByKO": 18,
     "age": 18,
-    "defaultStrategy": 3,
+    "defaultPlaybook": 3,
     "ruleset": 3,
     "titles": ["NABF"]
   },
@@ -1387,7 +1387,7 @@ export const BOXER_DATA = [
     "draws": 2,
     "winsByKO": 5,
     "age": 19,
-    "defaultStrategy": 3,
+    "defaultPlaybook": 3,
     "ruleset": 1
   },
   {
@@ -1406,7 +1406,7 @@ export const BOXER_DATA = [
     "draws": 0,
     "winsByKO": 3,
     "age": 40,
-    "defaultStrategy": 4,
+    "defaultPlaybook": 4,
     "ruleset": 3
   },
   {
@@ -1425,7 +1425,7 @@ export const BOXER_DATA = [
     "draws": 0,
     "winsByKO": 22,
     "age": 18,
-    "defaultStrategy": 4,
+    "defaultPlaybook": 4,
     "ruleset": 1
   },
   {
@@ -1444,7 +1444,7 @@ export const BOXER_DATA = [
     "draws": 2,
     "winsByKO": 3,
     "age": 30,
-    "defaultStrategy": 3,
+    "defaultPlaybook": 3,
     "ruleset": 2
   },
   {
@@ -1463,7 +1463,7 @@ export const BOXER_DATA = [
     "draws": 0,
     "winsByKO": 23,
     "age": 28,
-    "defaultStrategy": 3,
+    "defaultPlaybook": 3,
     "ruleset": 2
   },
   {
@@ -1482,7 +1482,7 @@ export const BOXER_DATA = [
     "draws": 3,
     "winsByKO": 12,
     "age": 30,
-    "defaultStrategy": 4,
+    "defaultPlaybook": 4,
     "ruleset": 3
   },
   {
@@ -1501,7 +1501,7 @@ export const BOXER_DATA = [
     "draws": 3,
     "winsByKO": 7,
     "age": 29,
-    "defaultStrategy": 6,
+    "defaultPlaybook": 6,
     "ruleset": 1
   },
   {
@@ -1520,7 +1520,7 @@ export const BOXER_DATA = [
     "draws": 1,
     "winsByKO": 2,
     "age": 26,
-    "defaultStrategy": 5,
+    "defaultPlaybook": 5,
     "ruleset": 1
   },
   {
@@ -1540,7 +1540,7 @@ export const BOXER_DATA = [
     "age": 37,
     "ruleset": 1,
     "ranking": 20,
-    "defaultStrategy": 6
+    "defaultPlaybook": 6
   },
   {
     "name": "Kevin Johnson",
@@ -1558,7 +1558,7 @@ export const BOXER_DATA = [
     "draws": 1,
     "winsByKO": 5,
     "age": 40,
-    "defaultStrategy": 6,
+    "defaultPlaybook": 6,
     "ruleset": 3
   },
   {
@@ -1577,7 +1577,7 @@ export const BOXER_DATA = [
     "draws": 3,
     "winsByKO": 9,
     "age": 22,
-    "defaultStrategy": 6,
+    "defaultPlaybook": 6,
     "ruleset": 3
   },
   {
@@ -1596,7 +1596,7 @@ export const BOXER_DATA = [
     "draws": 0,
     "winsByKO": 11,
     "age": 24,
-    "defaultStrategy": 6,
+    "defaultPlaybook": 6,
     "ruleset": 3
   },
   {
@@ -1615,7 +1615,7 @@ export const BOXER_DATA = [
     "draws": 1,
     "winsByKO": 2,
     "age": 22,
-    "defaultStrategy": 5,
+    "defaultPlaybook": 5,
     "ruleset": 2
   },
   {
@@ -1634,7 +1634,7 @@ export const BOXER_DATA = [
     "draws": 3,
     "winsByKO": 4,
     "age": 18,
-    "defaultStrategy": 3,
+    "defaultPlaybook": 3,
     "ruleset": 1,
     "titles": ["ABU"]
   },
@@ -1654,7 +1654,7 @@ export const BOXER_DATA = [
     "draws": 2,
     "winsByKO": 12,
     "age": 29,
-    "defaultStrategy": 3,
+    "defaultPlaybook": 3,
     "ruleset": 1
   },
   {
@@ -1673,7 +1673,7 @@ export const BOXER_DATA = [
     "draws": 3,
     "winsByKO": 5,
     "age": 19,
-    "defaultStrategy": 3,
+    "defaultPlaybook": 3,
     "ruleset": 2
   },
   {
@@ -1692,7 +1692,7 @@ export const BOXER_DATA = [
     "draws": 2,
     "winsByKO": 8,
     "age": 22,
-    "defaultStrategy": 3,
+    "defaultPlaybook": 3,
     "ruleset": 1
   },
   {
@@ -1711,7 +1711,7 @@ export const BOXER_DATA = [
     "draws": 2,
     "winsByKO": 2,
     "age": 24,
-    "defaultStrategy": 4,
+    "defaultPlaybook": 4,
     "ruleset": 2
   },
   {
@@ -1731,7 +1731,7 @@ export const BOXER_DATA = [
     "age": 30,
     "ruleset": 3,
     "ranking": 10,
-    "defaultStrategy": 4
+    "defaultPlaybook": 4
   },
   {
     "name": "Oscar Moore",
@@ -1749,7 +1749,7 @@ export const BOXER_DATA = [
     "draws": 1,
     "winsByKO": 12,
     "age": 20,
-    "defaultStrategy": 5,
+    "defaultPlaybook": 5,
     "ruleset": 2
   },
   {
@@ -1768,7 +1768,7 @@ export const BOXER_DATA = [
     "draws": 1,
     "winsByKO": 10,
     "age": 23,
-    "defaultStrategy": 5,
+    "defaultPlaybook": 5,
     "ruleset": 2,
     "titles": ["WBO"]
   },
@@ -1788,7 +1788,7 @@ export const BOXER_DATA = [
     "draws": 1,
     "winsByKO": 8,
     "age": 35,
-    "defaultStrategy": 5,
+    "defaultPlaybook": 5,
     "ruleset": 2
   },
   {
@@ -1807,7 +1807,7 @@ export const BOXER_DATA = [
     "draws": 0,
     "winsByKO": 2,
     "age": 28,
-    "defaultStrategy": 6,
+    "defaultPlaybook": 6,
     "ruleset": 2
   },
   {
@@ -1826,7 +1826,7 @@ export const BOXER_DATA = [
     "draws": 2,
     "winsByKO": 11,
     "age": 37,
-    "defaultStrategy": 6,
+    "defaultPlaybook": 6,
     "ruleset": 2,
     "titles": ["IBF"]
   },
@@ -1846,7 +1846,7 @@ export const BOXER_DATA = [
     "draws": 0,
     "winsByKO": 9,
     "age": 23,
-    "defaultStrategy": 7,
+    "defaultPlaybook": 7,
     "ruleset": 1
   },
   {
@@ -1865,7 +1865,7 @@ export const BOXER_DATA = [
     "draws": 1,
     "winsByKO": 16,
     "age": 31,
-    "defaultStrategy": 5,
+    "defaultPlaybook": 5,
     "ruleset": 2
   },
   {
@@ -1884,7 +1884,7 @@ export const BOXER_DATA = [
     "draws": 3,
     "winsByKO": 16,
     "age": 20,
-    "defaultStrategy": 5,
+    "defaultPlaybook": 5,
     "ruleset": 1
   },
   {
@@ -1904,7 +1904,7 @@ export const BOXER_DATA = [
     "age": 23,
     "ruleset": 3,
     "ranking": 1,
-    "defaultStrategy": 5,
+    "defaultPlaybook": 5,
     "titles": ["WBA", "WBC"]
   }
 ];

--- a/src/scripts/boxer.js
+++ b/src/scripts/boxer.js
@@ -44,7 +44,7 @@ export class Boxer {
     this.maxStamina = this.stamina;
     this.maxHealth = stats.health || 1;
     this.health = this.maxHealth;
-    this.defaultStrategy = stats.defaultStrategy || 1;
+    this.defaultPlaybook = stats.defaultPlaybook || 1;
     this.userCreated = stats.userCreated || false;
     this.perks = stats.perks || [];
     // slightly smaller boxer sprites

--- a/src/scripts/create-boxer-scene.js
+++ b/src/scripts/create-boxer-scene.js
@@ -2,7 +2,7 @@
 import { BOXERS, addBoxer } from './boxers.js';
 import { setPlayerBoxer } from './player-boxer.js';
 
-function defaultStrategyForRanking(ranking) {
+function defaultPlaybookForRanking(ranking) {
   if (ranking >= 80)  return Math.floor(Math.random() * 4) + 1;
   if (ranking >= 50)  return Math.floor(Math.random() * 3) + 2;
   if (ranking >= 11)  return Math.floor(Math.random() * 4) + 3;
@@ -102,7 +102,7 @@ export class CreateBoxerScene extends Phaser.Scene {
         age: state.age,
         stamina: state.stamina, power: state.power, health: state.health, speed: state.speed,
         ranking, matches: 0, wins: 0, losses: 0, draws: 0, winsByKO: 0,
-        defaultStrategy: defaultStrategyForRanking(ranking),
+        defaultPlaybook: defaultPlaybookForRanking(ranking),
         ruleset: state.ruleset, userCreated: true, titles: [], earnings: 0, bank: 0,
         perks: [],
       };

--- a/src/scripts/match-scene.js
+++ b/src/scripts/match-scene.js
@@ -1,6 +1,6 @@
 import { Boxer } from './boxer.js';
-import { StrategyAIController } from './strategy-ai-controller.js';
-import { getMaxStrategyLevel } from './player-boxer.js';
+import { PlaybookAIController } from './playbook-ai-controller.js';
+import { getMaxPlaybookLevel } from './player-boxer.js';
 import { KeyboardController } from './controllers.js';
 import { createBoxerAnimations } from './animation-factory.js';
 import { eventBus } from './event-bus.js';
@@ -45,13 +45,13 @@ export class MatchScene extends Phaser.Scene {
     createBoxerAnimations(this, BOXER_PREFIXES.P2);
 
     // Player 1 may be human or AI controlled; player 2 always AI
-    let level1 = data.boxer1?.defaultStrategy || 1;
+    let level1 = data.boxer1?.defaultPlaybook || 1;
     if (data.aiLevel1 && data.aiLevel1 !== 'default') {
       level1 = parseInt(data.aiLevel1, 10) || level1;
     }
-    level1 = Math.min(level1, getMaxStrategyLevel(data.boxer1));
+    level1 = Math.min(level1, getMaxPlaybookLevel(data.boxer1));
     const controller1 = data?.aiLevel1
-      ? new StrategyAIController(level1, 1)
+      ? new PlaybookAIController(level1, 1)
       : new KeyboardController(this, {
           block: 'S',
           jabRight: 'E',
@@ -67,9 +67,9 @@ export class MatchScene extends Phaser.Scene {
           right: 'D',
         });
     this.isP1AI = !!data?.aiLevel1;
-    const controller2 = new StrategyAIController(
+    const controller2 = new PlaybookAIController(
       data?.aiLevel2 === 'default'
-        ? data.boxer2?.defaultStrategy || 1
+        ? data.boxer2?.defaultPlaybook || 1
         : data?.aiLevel2 || 1,
       2
     );
@@ -326,13 +326,13 @@ export class MatchScene extends Phaser.Scene {
 
     if (this.debugVisible) {
       this.debugText.center.setText(`Distance: ${distance.toFixed(1)}`);
-      const strat1 =
+      const pb1 =
         typeof this.player1.controller.getLevel === 'function'
-          ? `Strategy: ${this.player1.controller.getLevel()}`
+          ? `Playbook: ${this.player1.controller.getLevel()}`
           : 'Human controlled boxer';
-      const strat2 =
+      const pb2 =
         typeof this.player2.controller.getLevel === 'function'
-          ? `Strategy: ${this.player2.controller.getLevel()}`
+          ? `Playbook: ${this.player2.controller.getLevel()}`
           : 'Human controlled boxer';
       const rule1 = `Ruleset: ruleset${this.rulesetId.p1} | ${
         this.ruleManager1.currentRule() || 'none'
@@ -340,8 +340,8 @@ export class MatchScene extends Phaser.Scene {
       const rule2 = `Ruleset: ruleset${this.rulesetId.p2} | ${
         this.ruleManager2.currentRule() || 'none'
       }`;
-      this.debugText.p1.setText(`${strat1}\n${rule1}`);
-      this.debugText.p2.setText(`${strat2}\n${rule2}`);
+      this.debugText.p1.setText(`${pb1}\n${rule1}`);
+      this.debugText.p2.setText(`${pb2}\n${rule2}`);
     }
 
     if (this.paused) return;
@@ -403,8 +403,8 @@ export class MatchScene extends Phaser.Scene {
     });
     this.roundHits.p1 = 0;
     this.roundHits.p2 = 0;
-    this.ruleManager1.resetStrategyChanges();
-    this.ruleManager2.resetStrategyChanges();
+    this.ruleManager1.resetPlaybookChanges();
+    this.ruleManager2.resetPlaybookChanges();
     this.paused = true;
     this.resetBoxers();
     if (round >= this.maxRounds) {
@@ -722,7 +722,7 @@ export class MatchScene extends Phaser.Scene {
     };
   }
 
-  setPlayerStrategy(player, level) {
+  setPlayerPlaybook(player, level) {
     const ctrl = player === 1 ? this.player1.controller : this.player2.controller;
     if (ctrl && ctrl.setLevel) ctrl.setLevel(level);
   }

--- a/src/scripts/overlay.js
+++ b/src/scripts/overlay.js
@@ -1,8 +1,8 @@
 import { eventBus } from './event-bus.js';
 import { appConfig, getTestMode } from './config.js';
 import { SoundManager } from './sound-manager.js';
-import { createStrategyLevelSelector } from './UIDialogControls.js';
-import { getMaxStrategyLevel, hasChangePerk } from './player-boxer.js';
+import { createPlaybookLevelSelector } from './UIDialogControls.js';
+import { getMaxPlaybookLevel, hasChangePerk } from './player-boxer.js';
 
 export class OverlayUI extends Phaser.Scene {
   constructor() {
@@ -11,7 +11,7 @@ export class OverlayUI extends Phaser.Scene {
     this.nextRoundText = null;
     this.continueText = null;
     this.matchOver = false;
-    this.strategyOptions = [];
+    this.playbookOptions = [];
     this.enterHandler = null;
     this.clickHandler = null;
     this.locationText = null;
@@ -370,7 +370,7 @@ export class OverlayUI extends Phaser.Scene {
     this.input.once('pointerup', this.nextRoundHandler);
     if (match?.isP1AI) {
       const locked = !getTestMode() && !hasChangePerk(match.player1);
-      this.showStrategyOptions(getMaxStrategyLevel(match.player1), locked);
+      this.showPlaybookOptions(getMaxPlaybookLevel(match.player1), locked);
     }
   }
 
@@ -379,7 +379,7 @@ export class OverlayUI extends Phaser.Scene {
       this.nextRoundHandler = null;
     }
     if (this.nextRoundText) this.nextRoundText.setVisible(false);
-    this.hideStrategyOptions();
+    this.hidePlaybookOptions();
     eventBus.emit('next-round');
   }
 
@@ -389,20 +389,20 @@ export class OverlayUI extends Phaser.Scene {
       this.input.off('pointerup', this.nextRoundHandler);
       this.nextRoundHandler = null;
     }
-    this.hideStrategyOptions();
+    this.hidePlaybookOptions();
   }
 
-  showStrategyOptions(maxLevel = 10, locked = false) {
+  showPlaybookOptions(maxLevel = 10, locked = false) {
     const match = this.scene.get('MatchScene');
     if (!match) return;
-    maxLevel = Math.min(maxLevel, getMaxStrategyLevel(match.player1));
+    maxLevel = Math.min(maxLevel, getMaxPlaybookLevel(match.player1));
     const controller = match.player1?.controller;
     if (!controller || typeof controller.getLevel !== 'function') return;
-    const defaultLevel = match.player1.stats?.defaultStrategy || 1;
+    const defaultLevel = match.player1.stats?.defaultPlaybook || 1;
     const current = controller.getLevel();
 
-    this.strategyOptions.forEach((o) => o.destroy());
-    this.strategyOptions = [];
+    this.playbookOptions.forEach((o) => o.destroy());
+    this.playbookOptions = [];
 
     const width = this.sys.game.config.width;
     const height = this.sys.game.config.height;
@@ -415,7 +415,7 @@ export class OverlayUI extends Phaser.Scene {
         ? (match.ringBounds.top + match.ringBounds.bottom) / 2
         : height / 2;
 
-    const dom = createStrategyLevelSelector(this, {
+    const dom = createPlaybookLevelSelector(this, {
       maxLevel,
       start: current,
       selectLabel: 'Ok',
@@ -430,14 +430,14 @@ export class OverlayUI extends Phaser.Scene {
           controller.setLevel(parseInt(level, 10));
         }
         SoundManager.playClick();
-        this.hideStrategyOptions();
+        this.hidePlaybookOptions();
       },
     });
-    this.strategyOptions.push(dom);
+    this.playbookOptions.push(dom);
   }
 
-  hideStrategyOptions() {
-    this.strategyOptions.forEach((o) => o.destroy());
-    this.strategyOptions = [];
+  hidePlaybookOptions() {
+    this.playbookOptions.forEach((o) => o.destroy());
+    this.playbookOptions = [];
   }
 }

--- a/src/scripts/perks-data.js
+++ b/src/scripts/perks-data.js
@@ -1,6 +1,6 @@
 export const PERKS = [
-  { "Name": "Strategy", "Level": 1, "Price": 20000 },
-  { "Name": "Strategy", "Level": 2, "Price": 50000 },
-  { "Name": "Strategy", "Level": 3, "Price": 50000 },
+  { "Name": "Playbook", "Level": 1, "Price": 20000 },
+  { "Name": "Playbook", "Level": 2, "Price": 50000 },
+  { "Name": "Playbook", "Level": 3, "Price": 50000 },
   { "Name": "Change", "Level": 1, "Price": 100000 }
 ];

--- a/src/scripts/playbook-ai-controller.js
+++ b/src/scripts/playbook-ai-controller.js
@@ -1,4 +1,4 @@
-import { STRATEGIES_P1, STRATEGIES_P2, createBaseActions } from './ai-strategies.js';
+import { PLAYBOOKS_P1, PLAYBOOKS_P2, createBaseActions } from './ai-playbooks.js';
 
 function convertAction(action, boxer, opponent) {
   if (action.none) return createBaseActions();
@@ -18,7 +18,7 @@ function convertAction(action, boxer, opponent) {
   return res;
 }
 
-export class StrategyAIController {
+export class PlaybookAIController {
   constructor(level = 1, boxerId = 1) {
     this.level = Phaser.Math.Clamp(level, 1, 10);
     this.index = 0;
@@ -40,10 +40,10 @@ export class StrategyAIController {
   }
 
   getActions(boxer, opponent, currentSecond) {
-    const strategies = this.boxerId === 1 ? STRATEGIES_P1 : STRATEGIES_P2;
-    const strategy = strategies[this.level - 1];
+    const playbooks = this.boxerId === 1 ? PLAYBOOKS_P1 : PLAYBOOKS_P2;
+    const playbook = playbooks[this.level - 1];
     if (currentSecond !== this.lastDecision) {
-      const action = strategy.actions[this.index % strategy.actions.length];
+      const action = playbook.actions[this.index % playbook.actions.length];
       this.cached = convertAction(action, boxer, opponent);
       this.index += 1;
       this.lastDecision = currentSecond;

--- a/src/scripts/player-boxer.js
+++ b/src/scripts/player-boxer.js
@@ -14,16 +14,16 @@ export function getPlayerBoxer() {
   return playerBoxer;
 }
 
-export function getStrategyPerkLevel(boxer = playerBoxer) {
+export function getPlaybookPerkLevel(boxer = playerBoxer) {
   if (!boxer?.perks) return 0;
   return boxer.perks
-    .filter((p) => p.Name === 'Strategy')
+    .filter((p) => p.Name === 'Playbook')
     .reduce((max, p) => Math.max(max, p.Level), 0);
 }
 
-export function getMaxStrategyLevel(boxer = playerBoxer) {
+export function getMaxPlaybookLevel(boxer = playerBoxer) {
   if (getTestMode()) return 10;
-  const lvl = getStrategyPerkLevel(boxer);
+  const lvl = getPlaybookPerkLevel(boxer);
   if (lvl >= 3) return 10;
   if (lvl === 2) return 6;
   if (lvl === 1) return 3;

--- a/src/scripts/rule-manager.js
+++ b/src/scripts/rule-manager.js
@@ -1,4 +1,4 @@
-import { STRATEGIES_P1, STRATEGIES_P2 } from './ai-strategies.js';
+import { PLAYBOOKS_P1, PLAYBOOKS_P2 } from './ai-playbooks.js';
 import { showComment } from './comment-manager.js';
 
 export class RuleManager {
@@ -8,7 +8,7 @@ export class RuleManager {
     this.activeRule = null;
     this.activeUntil = 0;
     this.boxerRules = { p1: null, p2: null };
-    this.lastStrategyMinute = { p1: -1, p2: -1 };
+    this.lastPlaybookMinute = { p1: -1, p2: -1 };
   }
 
   fill(actions, start, seq) {
@@ -28,16 +28,16 @@ export class RuleManager {
 
   canShift(boxer, currentSecond) {
     const minute = Math.floor(currentSecond / 60);
-    if (this.lastStrategyMinute[boxer] !== minute) {
-      this.lastStrategyMinute[boxer] = minute;
+    if (this.lastPlaybookMinute[boxer] !== minute) {
+      this.lastPlaybookMinute[boxer] = minute;
       return true;
     }
     return false;
   }
 
-  resetStrategyChanges() {
-    this.lastStrategyMinute.p1 = -1;
-    this.lastStrategyMinute.p2 = -1;
+  resetPlaybookChanges() {
+    this.lastPlaybookMinute.p1 = -1;
+    this.lastPlaybookMinute.p2 = -1;
   }
 
   evaluate(currentSecond) {
@@ -62,8 +62,8 @@ export class RuleManager {
         try{
           const ctrl = boxer.controller;
           if (typeof ctrl.getLevel === 'function') {
-            const strategies = boxer === this.b1 ? STRATEGIES_P1 : STRATEGIES_P2;
-            return strategies[ctrl.getLevel() - 1].actions;
+            const playbooks = boxer === this.b1 ? PLAYBOOKS_P1 : PLAYBOOKS_P2;
+            return playbooks[ctrl.getLevel() - 1].actions;
           }          
         }
         catch(exception){

--- a/src/scripts/ruleset1-manager.js
+++ b/src/scripts/ruleset1-manager.js
@@ -1,4 +1,4 @@
-import { STRATEGIES_P1, STRATEGIES_P2 } from './ai-strategies.js';
+import { PLAYBOOKS_P1, PLAYBOOKS_P2 } from './ai-playbooks.js';
 import { showComment } from './comment-manager.js';
 
 export class RuleSet1Manager {
@@ -7,7 +7,7 @@ export class RuleSet1Manager {
     this.opp = opponentBoxer;
     this.activeRule = null;
     this.activeUntil = 0;
-    this.lastStrategyMinute = -1;
+    this.lastPlaybookMinute = -1;
     this.name = 'ruleset1';
   }
 
@@ -28,15 +28,15 @@ export class RuleSet1Manager {
 
   canShift(currentSecond) {
     const minute = Math.floor(currentSecond / 60);
-    if (this.lastStrategyMinute !== minute) {
-      this.lastStrategyMinute = minute;
+    if (this.lastPlaybookMinute !== minute) {
+      this.lastPlaybookMinute = minute;
       return true;
     }
     return false;
   }
 
-  resetStrategyChanges() {
-    this.lastStrategyMinute = -1;
+  resetPlaybookChanges() {
+    this.lastPlaybookMinute = -1;
   }
 
   currentRule() {
@@ -46,8 +46,8 @@ export class RuleSet1Manager {
   getActions() {
     const ctrl = this.self.controller;
     if (typeof ctrl.getLevel === 'function') {
-      const strategies = ctrl.boxerId === 2 ? STRATEGIES_P2 : STRATEGIES_P1;
-      return strategies[ctrl.getLevel() - 1].actions;
+      const playbooks = ctrl.boxerId === 2 ? PLAYBOOKS_P2 : PLAYBOOKS_P1;
+      return playbooks[ctrl.getLevel() - 1].actions;
     }
     return null;
   }

--- a/src/scripts/ruleset2-manager.js
+++ b/src/scripts/ruleset2-manager.js
@@ -1,4 +1,4 @@
-import { STRATEGIES_P1, STRATEGIES_P2 } from './ai-strategies.js';
+import { PLAYBOOKS_P1, PLAYBOOKS_P2 } from './ai-playbooks.js';
 import { showComment } from './comment-manager.js';
 
 export class RuleSet2Manager {
@@ -7,7 +7,7 @@ export class RuleSet2Manager {
     this.opp = opponentBoxer;
     this.activeRule = null;
     this.activeUntil = 0;
-    this.lastStrategyMinute = -1;
+    this.lastPlaybookMinute = -1;
     this.name = 'ruleset2';
   }
 
@@ -28,15 +28,15 @@ export class RuleSet2Manager {
 
   canShift(currentSecond) {
     const minute = Math.floor(currentSecond / 60);
-    if (this.lastStrategyMinute !== minute) {
-      this.lastStrategyMinute = minute;
+    if (this.lastPlaybookMinute !== minute) {
+      this.lastPlaybookMinute = minute;
       return true;
     }
     return false;
   }
 
-  resetStrategyChanges() {
-    this.lastStrategyMinute = -1;
+  resetPlaybookChanges() {
+    this.lastPlaybookMinute = -1;
   }
 
   currentRule() {
@@ -46,8 +46,8 @@ export class RuleSet2Manager {
   getActions() {
     const ctrl = this.self.controller;
     if (typeof ctrl.getLevel === 'function') {
-      const strategies = ctrl.boxerId === 2 ? STRATEGIES_P2 : STRATEGIES_P1;
-      return strategies[ctrl.getLevel() - 1].actions;
+      const playbooks = ctrl.boxerId === 2 ? PLAYBOOKS_P2 : PLAYBOOKS_P1;
+      return playbooks[ctrl.getLevel() - 1].actions;
     }
     return null;
   }

--- a/src/scripts/ruleset3-manager.js
+++ b/src/scripts/ruleset3-manager.js
@@ -1,4 +1,4 @@
-import { STRATEGIES_P1, STRATEGIES_P2 } from './ai-strategies.js';
+import { PLAYBOOKS_P1, PLAYBOOKS_P2 } from './ai-playbooks.js';
 import { showComment } from './comment-manager.js';
 
 export class RuleSet3Manager {
@@ -7,7 +7,7 @@ export class RuleSet3Manager {
     this.opp = opponentBoxer;
     this.activeRule = null;
     this.activeUntil = 0;
-    this.lastStrategyMinute = -1;
+    this.lastPlaybookMinute = -1;
     this.name = 'ruleset3';
   }
 
@@ -28,15 +28,15 @@ export class RuleSet3Manager {
 
   canShift(currentSecond) {
     const minute = Math.floor(currentSecond / 60);
-    if (this.lastStrategyMinute !== minute) {
-      this.lastStrategyMinute = minute;
+    if (this.lastPlaybookMinute !== minute) {
+      this.lastPlaybookMinute = minute;
       return true;
     }
     return false;
   }
 
-  resetStrategyChanges() {
-    this.lastStrategyMinute = -1;
+  resetPlaybookChanges() {
+    this.lastPlaybookMinute = -1;
   }
 
   currentRule() {
@@ -46,8 +46,8 @@ export class RuleSet3Manager {
   getActions() {
     const ctrl = this.self.controller;
     if (typeof ctrl.getLevel === 'function') {
-      const strategies = ctrl.boxerId === 2 ? STRATEGIES_P2 : STRATEGIES_P1;
-      return strategies[ctrl.getLevel() - 1].actions;
+      const playbooks = ctrl.boxerId === 2 ? PLAYBOOKS_P2 : PLAYBOOKS_P1;
+      return playbooks[ctrl.getLevel() - 1].actions;
     }
     return null;
   }

--- a/src/scripts/save-system.js
+++ b/src/scripts/save-system.js
@@ -59,7 +59,7 @@ export function saveGameState(boxers) {
             power: b.power,
             health: b.health,
             speed: b.speed,
-            defaultStrategy: b.defaultStrategy,
+            defaultPlaybook: b.defaultPlaybook,
             ruleset: b.ruleset,
             earnings: b.earnings || 0,
             bank: b.bank || 0,
@@ -105,7 +105,7 @@ export function applyLoadedState(state) {
         losses: saved.losses ?? 0,
         draws: saved.draws ?? 0,
         winsByKO: saved.winsByKO ?? 0,
-        defaultStrategy: saved.defaultStrategy ?? 1,
+        defaultPlaybook: saved.defaultPlaybook ?? 1,
         ruleset: saved.ruleset ?? 1,
         userCreated: true,
         titles: saved.titles ?? [],
@@ -138,8 +138,8 @@ export function applyLoadedState(state) {
       boxer.power = saved.power ?? boxer.power;
       boxer.health = saved.health ?? boxer.health;
       boxer.speed = saved.speed ?? boxer.speed;
-      boxer.defaultStrategy =
-        saved.defaultStrategy ?? boxer.defaultStrategy;
+      boxer.defaultPlaybook =
+        saved.defaultPlaybook ?? boxer.defaultPlaybook;
       boxer.ruleset = saved.ruleset ?? boxer.ruleset;
       setPlayerBoxer(boxer);
     }

--- a/src/scripts/select-boxer-scene.js
+++ b/src/scripts/select-boxer-scene.js
@@ -1,9 +1,9 @@
 import { getRankings, getMatchPreview } from './boxer-stats.js';
 import { getTestMode, tableAlpha } from './config.js';
-import { getPlayerBoxer, getMaxStrategyLevel } from './player-boxer.js';
+import { getPlayerBoxer, getMaxPlaybookLevel } from './player-boxer.js';
 import { SoundManager } from './sound-manager.js';
 import { scheduleMatch, getPendingMatch } from './next-match.js';
-import { createStrategyLevelSelector, createRoundSelector } from './UIDialogControls.js';
+import { createPlaybookLevelSelector, createRoundSelector } from './UIDialogControls.js';
 
 export class SelectBoxerScene extends Phaser.Scene {
   constructor() {
@@ -11,8 +11,8 @@ export class SelectBoxerScene extends Phaser.Scene {
     this.step = 1;
     this.choice = [];
     this.options = [];
-    this.selectedStrategy1 = null;
-    this.selectedStrategy2 = null;
+    this.selectedPlaybook1 = null;
+    this.selectedPlaybook2 = null;
     this.isBoxer1Human = false;
     this.selectedRounds = null;
   }
@@ -114,13 +114,13 @@ export class SelectBoxerScene extends Phaser.Scene {
     });
   }
 
-  showStrategyOptions(maxLevel) {
+  showPlaybookOptions(maxLevel) {
     this.clearOptions();
-    const dom = createStrategyLevelSelector(this, {
+    const dom = createPlaybookLevelSelector(this, {
       maxLevel,
       onSelect: (level) => {
         this.options = (this.options || []).filter((o) => o !== dom);
-        this.selectStrategy(level);
+        this.selectPlaybook(level);
       },
     });
     (this.options ||= []).push(dom);
@@ -257,14 +257,14 @@ export class SelectBoxerScene extends Phaser.Scene {
     SoundManager.playClick();
     this.isBoxer1Human = mode === 'human';
     if (this.isBoxer1Human) {
-      this.selectedStrategy1 = 'default';
+      this.selectedPlaybook1 = 'default';
       this.step = 2;
       this.instruction.setText('Choose your opponent');
       this.showOpponentOptions();
     } else {
       this.step = 1;
-      this.instruction.setText('Choose Player 1 strategy');
-      this.showStrategyOptions(getMaxStrategyLevel());
+      this.instruction.setText('Choose Player 1 playbook');
+      this.showPlaybookOptions(getMaxPlaybookLevel());
     }
   }
 
@@ -281,7 +281,7 @@ export class SelectBoxerScene extends Phaser.Scene {
     SoundManager.playClick();
     if (!getTestMode() && this.step === 2) {
       this.choice.push(boxer);
-      this.selectedStrategy2 = 'default';
+      this.selectedPlaybook2 = 'default';
       this.step = 3;
       this.showRoundOptions();
       return;
@@ -296,10 +296,10 @@ export class SelectBoxerScene extends Phaser.Scene {
       } else {
         if (getTestMode()) {
           this.step = 2;
-          this.instruction.setText('Choose Player 1 strategy');
-          this.showStrategyOptions(10);
+          this.instruction.setText('Choose Player 1 playbook');
+          this.showPlaybookOptions(10);
         } else {
-          this.selectedStrategy1 = 'default';
+          this.selectedPlaybook1 = 'default';
           this.step = 2;
           this.instruction.setText('Choose your opponent');
           this.showOpponentOptions();
@@ -308,33 +308,33 @@ export class SelectBoxerScene extends Phaser.Scene {
     } else if (this.step === 3) {
       if (getTestMode()) {
         this.step = 4;
-        this.instruction.setText("Choose the opponent's strategy");
-        this.showStrategyOptions(10);
+        this.instruction.setText("Choose the opponent's playbook");
+        this.showPlaybookOptions(10);
       } else {
-        this.selectedStrategy2 = 'default';
+        this.selectedPlaybook2 = 'default';
         this.step = 5;
         this.showRoundOptions();
       }
     }
   }
 
-  selectStrategy(level) {
+  selectPlaybook(level) {
     SoundManager.playClick();
     if (this.step === 1) {
-      // non-test mode: player strategy selection
-      this.selectedStrategy1 = level;
+      // non-test mode: player playbook selection
+      this.selectedPlaybook1 = level;
       this.step = 2;
       this.instruction.setText('Choose your opponent');
       this.showOpponentOptions();
     } else if (this.step === 2) {
-      // test mode: player strategy selection
-      this.selectedStrategy1 = level;
+      // test mode: player playbook selection
+      this.selectedPlaybook1 = level;
       this.step = 3;
       this.instruction.setText('Choose your opponent');
       this.showBoxerOptions();
     } else if (this.step === 4) {
-      // test mode: opponent strategy selection
-      this.selectedStrategy2 = level;
+      // test mode: opponent playbook selection
+      this.selectedPlaybook2 = level;
       this.step = 5;
       this.showRoundOptions();
     }
@@ -356,8 +356,8 @@ export class SelectBoxerScene extends Phaser.Scene {
     const rounds = this.selectedRounds ?? 1;
     const aiLevel1 = this.isBoxer1Human
       ? null
-      : this.selectedStrategy1 ?? 'default';
-    const aiLevel2 = this.selectedStrategy2 ?? 'default';
+      : this.selectedPlaybook1 ?? 'default';
+    const aiLevel2 = this.selectedPlaybook2 ?? 'default';
     scheduleMatch({ boxer1, boxer2, aiLevel1, aiLevel2, rounds });
     const pending = getPendingMatch();
     if (pending) {
@@ -370,8 +370,8 @@ export class SelectBoxerScene extends Phaser.Scene {
 
   resetSelection() {
     this.choice = [];
-    this.selectedStrategy1 = null;
-    this.selectedStrategy2 = null;
+    this.selectedPlaybook1 = null;
+    this.selectedPlaybook2 = null;
     this.selectedRounds = null;
     this.isBoxer1Human = false;
     if (!getTestMode() && getPlayerBoxer()) {


### PR DESCRIPTION
## Summary
- rename strategy AI modules to playbook equivalents
- update UI and scenes to use playbook terminology
- adjust perks and player utilities for playbook levels

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689ca0685e50832a9f4a6061018a2d2f