### PR TITLE
Add Buy Perks to ranking and Back navigation

### DIFF
--- a/src/scripts/calendar-scene.js
+++ b/src/scripts/calendar-scene.js
@@ -9,6 +9,7 @@ import { getPendingMatch, clearPendingMatch } from './next-match.js';
 import { getMatchLog } from './match-log.js';
 import { SoundManager } from './sound-manager.js';
 import { formatMoney } from './helpers.js';
+import { createGloveButton } from './glove-button.js';
 
 export class CalendarScene extends Phaser.Scene {
   constructor() {
@@ -19,6 +20,7 @@ export class CalendarScene extends Phaser.Scene {
 
   create() {
     const width = this.sys.game.config.width;
+    const height = this.sys.game.config.height;
     SoundManager.playMenuLoop();
     const pending = getPendingMatch();
     if (!pending) {
@@ -49,6 +51,12 @@ export class CalendarScene extends Phaser.Scene {
       .setOrigin(0.5, 0);
 
     this.render();
+
+    const back = () => {
+      this.scene.start('Ranking');
+    };
+    createGloveButton(this, 150, height * 0.93, 'Cancel', back, { width: 300 });
+    this.input.keyboard.on('keydown-BACKSPACE', back);
   }
 
   formatResult(match) {

--- a/src/scripts/create-boxer-scene.js
+++ b/src/scripts/create-boxer-scene.js
@@ -311,6 +311,7 @@ export class CreateBoxerScene extends Phaser.Scene {
 
     // Hotkeys
     this.input.keyboard.on('keydown-ESC',   goBack);
+    this.input.keyboard.on('keydown-BACKSPACE', goBack);
     this.input.keyboard.on('keydown-ENTER', doCreate);
 
     // Städning

--- a/src/scripts/match-log-scene.js
+++ b/src/scripts/match-log-scene.js
@@ -50,29 +50,6 @@ export class MatchLogScene extends Phaser.Scene {
       } else if (boxer === getPlayerBoxer()) {
         headerY = 120;
       }
-      if (boxer === getPlayerBoxer()) {
-        const addBtn = this.add.container(width - startX - 32, perksY);
-        addBtn.add(
-          this.add.image(0, 0, 'fight_card').setDisplaySize(64, 64)
-        );
-        addBtn.add(
-          this.add.image(0, 0, 'perk_add').setDisplaySize(54, 54)
-        );
-        addBtn.add(
-          this.add
-            .text(-40, 0, 'Buy perks', {
-              font: '20px Arial',
-              color: '#ffff00',
-            })
-            .setOrigin(1, 0.5)
-        );
-        addBtn.setSize(64, 64);
-        addBtn
-          .setInteractive({ useHandCursor: true })
-          .on('pointerdown', () => {
-            this.scene.start('PerksScene');
-          });
-      }
     }
 
     this.log = getMatchLog(boxer?.name);
@@ -182,6 +159,9 @@ export class MatchLogScene extends Phaser.Scene {
       .on('pointerup', () => {
         this.scene.start('Ranking');
       });
+    this.input.keyboard.on('keydown-BACKSPACE', () => {
+      this.scene.start('Ranking');
+    });
   }
 
   renderRows() {

--- a/src/scripts/options-scene.js
+++ b/src/scripts/options-scene.js
@@ -171,6 +171,7 @@ export class OptionsScene extends Phaser.Scene {
 
     this.input.keyboard.on('keydown-ESC', back);
     this.input.keyboard.on('keydown-ENTER', back);
+    this.input.keyboard.on('keydown-BACKSPACE', back);
 
     // Städa alla lyssnare vid shutdown (säkerhetsnät)
     this.events.once(Phaser.Scenes.Events.SHUTDOWN, () => {

--- a/src/scripts/perks-scene.js
+++ b/src/scripts/perks-scene.js
@@ -113,14 +113,16 @@ export class PerksScene extends Phaser.Scene {
 
     updateButtons();
 
+    const goBack = () => {
+      this.scene.start('MatchLog', { boxer: player });
+    };
     this.add
       .text(20, height - 40, 'Back', {
         font: '24px Arial',
         color: '#ffff00',
       })
       .setInteractive({ useHandCursor: true })
-      .on('pointerdown', () => {
-        this.scene.start('MatchLog', { boxer: player });
-      });
+      .on('pointerdown', goBack);
+    this.input.keyboard.on('keydown-BACKSPACE', goBack);
   }
 }

--- a/src/scripts/ranking-scene.js
+++ b/src/scripts/ranking-scene.js
@@ -282,7 +282,17 @@ export class RankingScene extends Phaser.Scene {
       createGloveButton(this, width / 2, btnY, 'Next fight', goToSetup);
       this.input.keyboard.on('keydown-ENTER', goToSetup);
       this.input.keyboard.on('keydown-SPACE', goToSetup);
+      const perksY = btnY + 100;
+      createGloveButton(this, width / 2, perksY, 'Buy perks', () => {
+        this.scene.start('PerksScene');
+      });
     }
+
+    const back = () => {
+      this.scene.start('StartScene');
+    };
+    createGloveButton(this, 150, height * 0.93, 'Back', back, { width: 300 });
+    this.input.keyboard.on('keydown-BACKSPACE', back);
   }
 }
 

--- a/src/scripts/select-boxer-scene.js
+++ b/src/scripts/select-boxer-scene.js
@@ -4,6 +4,7 @@ import { getPlayerBoxer, getMaxPlaybookLevel } from './player-boxer.js';
 import { SoundManager } from './sound-manager.js';
 import { scheduleMatch, getPendingMatch } from './next-match.js';
 import { createPlaybookLevelSelector, createRoundSelector } from './UIDialogControls.js';
+import { createGloveButton } from './glove-button.js';
 
 export class SelectBoxerScene extends Phaser.Scene {
   constructor() {
@@ -19,6 +20,7 @@ export class SelectBoxerScene extends Phaser.Scene {
 
   create() {
     const width = this.sys.game.config.width;
+    const height = this.sys.game.config.height;
     this.instruction = this.add
       .text(width / 2, 20, '', {
         font: '24px Arial',
@@ -57,6 +59,12 @@ export class SelectBoxerScene extends Phaser.Scene {
     // reused.  Reset everything so that the boxer options can be
     // selected again.
     this.resetSelection();
+
+    const back = () => {
+      this.scene.start('Ranking');
+    };
+    createGloveButton(this, 150, height * 0.93, 'Back', back, { width: 300 });
+    this.input.keyboard.on('keydown-BACKSPACE', back);
   }
 
   showBoxerOptions() {
@@ -132,7 +140,7 @@ export class SelectBoxerScene extends Phaser.Scene {
     const height = this.sys.game.config.height;
     const spacing = 40;
     const startX = (width - (300 * 2 + spacing)) / 2 + 150;
-    const centerY = height / 2;
+    const centerY = height * 0.4;
 
     const makeOption = (x, label, icon, handler) => {
       const container = this.add.container(x, centerY);


### PR DESCRIPTION
## Summary
- Move "Buy perks" button to Ranking scene and add Back button support
- Raise control selection buttons and support Backspace to navigate back
- Add Cancel button on Calendar scene returning to rankings

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689ca8260038832a80e6c42548ffeca8