### PR TITLE
Standardize back buttons and update perks navigation

### DIFF
--- a/src/scripts/create-boxer-scene.js
+++ b/src/scripts/create-boxer-scene.js
@@ -116,7 +116,10 @@ export class CreateBoxerScene extends Phaser.Scene {
       this.scene.start('Ranking');
     };
 
-    const backLink = makeLink('Back', panelX + panelW * 0.25, () => goBack());
+    this.add
+      .text(20, H - 40, 'Back', { font: '24px Arial', color: '#ffff00' })
+      .setInteractive({ useHandCursor: true })
+      .on('pointerdown', goBack);
 
     let createLink = null; // IMPORTANT: deklarerad innan setCreateEnabled används
     const setCreateEnabled = (enabled) => {

--- a/src/scripts/match-log-scene.js
+++ b/src/scripts/match-log-scene.js
@@ -134,34 +134,14 @@ export class MatchLogScene extends Phaser.Scene {
       });
     }
 
-    const btnX = width / 2;
-    const btnY = height * 0.93;
-    const bgColor = 0x001b44;
-    const bgAlpha = 0.4;
-    const backBtn = this.add.container(btnX, btnY);
-    backBtn.setSize(500, 80);
-    const bg = this.add.rectangle(0, 0, 500, 80, bgColor, bgAlpha);
-    const label = this.add
-      .text(0, 0, 'Back', { font: '32px Arial', color: '#ffffff' })
-      .setOrigin(0.5);
-    const gloveL = this.add
-      .image(-300, 0, 'glove_horizontal')
-      .setDisplaySize(100, 70);
-    const gloveR = this.add
-      .image(300, 0, 'glove_horizontal')
-      .setDisplaySize(100, 70)
-      .setFlipX(true);
-    backBtn.add([bg, label, gloveL, gloveR]);
-    this.tweens.add({ targets: gloveL, x: -150, duration: 800, ease: 'Sine.Out' });
-    this.tweens.add({ targets: gloveR, x: 150, duration: 800, ease: 'Sine.Out' });
-    backBtn
-      .setInteractive({ useHandCursor: true })
-      .on('pointerup', () => {
-        this.scene.start('Ranking');
-      });
-    this.input.keyboard.on('keydown-BACKSPACE', () => {
+    const goBack = () => {
       this.scene.start('Ranking');
-    });
+    };
+    this.add
+      .text(20, height - 40, 'Back', { font: '24px Arial', color: '#ffff00' })
+      .setInteractive({ useHandCursor: true })
+      .on('pointerdown', goBack);
+    this.input.keyboard.on('keydown-BACKSPACE', goBack);
   }
 
   renderRows() {

--- a/src/scripts/options-scene.js
+++ b/src/scripts/options-scene.js
@@ -167,7 +167,10 @@ export class OptionsScene extends Phaser.Scene {
         this.scene.start('StartScene');
       }
     };
-    makeLink('Back', panelX + panelW * 0.78, back);
+    this.add
+      .text(20, H - 40, 'Back', { font: '24px Arial', color: '#ffff00' })
+      .setInteractive({ useHandCursor: true })
+      .on('pointerdown', back);
 
     this.input.keyboard.on('keydown-ESC', back);
     this.input.keyboard.on('keydown-ENTER', back);

--- a/src/scripts/perks-scene.js
+++ b/src/scripts/perks-scene.js
@@ -114,7 +114,7 @@ export class PerksScene extends Phaser.Scene {
     updateButtons();
 
     const goBack = () => {
-      this.scene.start('MatchLog', { boxer: player });
+      this.scene.start('Ranking');
     };
     this.add
       .text(20, height - 40, 'Back', {

--- a/src/scripts/ranking-scene.js
+++ b/src/scripts/ranking-scene.js
@@ -283,16 +283,20 @@ export class RankingScene extends Phaser.Scene {
       this.input.keyboard.on('keydown-ENTER', goToSetup);
       this.input.keyboard.on('keydown-SPACE', goToSetup);
       const perksY = btnY + 100;
-      createGloveButton(this, width / 2, perksY, 'Buy perks', () => {
-        this.scene.start('PerksScene');
-      });
+      this.add
+        .image(width / 2, perksY, 'perk_add')
+        .setDisplaySize(80, 80)
+        .setInteractive({ useHandCursor: true })
+        .on('pointerup', () => {
+          this.scene.start('PerksScene');
+        });
+      this.add
+        .text(width / 2, perksY + 50, 'Buy perks', {
+          font: '24px Arial',
+          color: '#ffff00',
+        })
+        .setOrigin(0.5, 0);
     }
-
-    const back = () => {
-      this.scene.start('StartScene');
-    };
-    createGloveButton(this, 150, height * 0.93, 'Back', back, { width: 300 });
-    this.input.keyboard.on('keydown-BACKSPACE', back);
   }
 }
 

--- a/src/scripts/select-boxer-scene.js
+++ b/src/scripts/select-boxer-scene.js
@@ -63,7 +63,10 @@ export class SelectBoxerScene extends Phaser.Scene {
     const back = () => {
       this.scene.start('Ranking');
     };
-    createGloveButton(this, 150, height * 0.93, 'Back', back, { width: 300 });
+    this.add
+      .text(20, height - 40, 'Back', { font: '24px Arial', color: '#ffff00' })
+      .setInteractive({ useHandCursor: true })
+      .on('pointerdown', back);
     this.input.keyboard.on('keydown-BACKSPACE', back);
   }
 


### PR DESCRIPTION
## Summary
- remove back button from ranking scene and use add icon for perks access
- send perks scene back to ranking
- unify all remaining back buttons as yellow text links in the lower-left corner

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689cac5187b4832a96b578291da55a44