### PR TITLE
Add transaction descriptions and start money slider

### DIFF
--- a/src/scripts/bank-account.js
+++ b/src/scripts/bank-account.js
@@ -6,7 +6,15 @@ function loadTransactions() {
     const raw = localStorage.getItem(BANK_KEY);
     if (!raw) return [];
     const data = JSON.parse(raw);
-    return Array.isArray(data) ? data : [];
+    if (!Array.isArray(data)) return [];
+    return data.map((t) => {
+      if (typeof t === 'number') {
+        return { amount: t, description: '' };
+      }
+      const amt = typeof t?.amount === 'number' ? t.amount : 0;
+      const desc = typeof t?.description === 'string' ? t.description : '';
+      return { amount: amt, description: desc };
+    });
   } catch (err) {
     return [];
   }
@@ -21,9 +29,9 @@ function saveTransactions(txs) {
   }
 }
 
-export function addTransaction(amount) {
+export function addTransaction(amount, description = '') {
   const txs = loadTransactions();
-  txs.push(amount);
+  txs.push({ amount, description });
   saveTransactions(txs);
 }
 
@@ -32,7 +40,7 @@ export function getTransactions() {
 }
 
 export function getBalance() {
-  return loadTransactions().reduce((sum, v) => sum + v, 0);
+  return loadTransactions().reduce((sum, v) => sum + (v.amount || 0), 0);
 }
 
 export function resetBankAccount() {

--- a/src/scripts/boxer-stats.js
+++ b/src/scripts/boxer-stats.js
@@ -83,8 +83,8 @@ function awardEarnings(b1, b2, winner) {
   b1.bank = (b1.bank || 0) + b1Prize;
   b2.bank = (b2.bank || 0) + b2Prize;
   const player = getPlayerBoxer();
-  if (b1 === player) addTransaction(b1Prize);
-  if (b2 === player) addTransaction(b2Prize);
+  if (b1 === player) addTransaction(b1Prize, 'Prize money');
+  if (b2 === player) addTransaction(b2Prize, 'Prize money');
 }
 
 // Record a win/loss result between two boxers.

--- a/src/scripts/perks-scene.js
+++ b/src/scripts/perks-scene.js
@@ -47,7 +47,7 @@ export class PerksScene extends Phaser.Scene {
     const renderTransactions = () => {
       txTexts.forEach((t) => t.destroy());
       txTexts = [];
-      const txStartX = leftMargin + 500;
+      const txStartX = leftMargin + 700;
       txTexts.push(
         this.add.text(txStartX, startY - 40, 'Transactions', {
           font: '24px Arial',
@@ -56,9 +56,12 @@ export class PerksScene extends Phaser.Scene {
       );
       getTransactions()
         .slice()
-        .forEach((amt, idx) => {
+        .forEach((tx, idx) => {
+          const text = `${tx.description ? tx.description + ': ' : ''}${formatMoney(
+            tx.amount
+          )}`;
           txTexts.push(
-            this.add.text(txStartX, startY + idx * 30, formatMoney(amt), {
+            this.add.text(txStartX, startY + idx * 30, text, {
               font: '20px Arial',
               color: '#ffffff',
             })
@@ -121,7 +124,7 @@ export class PerksScene extends Phaser.Scene {
               (p) => p.Name === perk.Name && p.Level === perk.Level - 1
             );
           if (!prereq) return;
-          addTransaction(-perk.Price);
+          addTransaction(-perk.Price, `Buy perk ${perk.Name}`);
           player.bank = (player.bank || 0) - perk.Price;
         }
         player.perks.push({ ...perk });


### PR DESCRIPTION
## Summary
- track transaction descriptions in bank account
- shift transaction table right and label purchases and prize money
- add test-mode Start money slider with Creation bonus transaction

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node --check src/scripts/bank-account.js src/scripts/boxer-stats.js src/scripts/create-boxer-scene.js src/scripts/perks-scene.js`

------
https://chatgpt.com/codex/tasks/task_e_689cc0e955e0832a82580e9d38d1b4d8