### PR TITLE
fix: avoid skipping game results

### DIFF
--- a/src/scripts/game-result-scene.js
+++ b/src/scripts/game-result-scene.js
@@ -123,8 +123,11 @@ export class GameResultScene extends Phaser.Scene {
         this.scene.start('Ranking');
       }
     };
-    cont.once('pointerup', goNext);
-    this.input.keyboard.once('keydown', goNext);
+    // Require a fresh click or key press so the result screen isn't skipped
+    cont.once('pointerdown', goNext);
+    this.input.keyboard.once('keyup', () => {
+      this.input.keyboard.once('keydown', goNext);
+    });
   }
 }
 


### PR DESCRIPTION
## Summary
- prevent GameResultScene from instantly skipping when continue is clicked
- require a new click or key press to move past the result screen

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689cc61981e4832a907f2f01e10980bb