### PR TITLE
feat: consolidate match setup flow

### DIFF
--- a/src/scripts/main.js
+++ b/src/scripts/main.js
@@ -7,6 +7,7 @@ import { CreateBoxerScene } from './create-boxer-scene.js';
 import { MatchLogScene } from './match-log-scene.js';
 import { StartScene } from './start-scene.js';
 import { OptionsScene } from './options-scene.js';
+import { MatchSetupScene } from './match-setup-scene.js';
 import { PerksScene } from './perks-scene.js';
 import { BackdropManager } from './backdrop-manager.js';
 import { MatchIntroScene } from './match-intro-scene.js';
@@ -179,6 +180,7 @@ const config = {
     PerksScene,
     CreateBoxerScene,
     OptionsScene,
+    MatchSetupScene,
     SelectBoxerScene,
     CalendarScene,
     MatchIntroScene,

--- a/src/scripts/match-setup-scene.js
+++ b/src/scripts/match-setup-scene.js
@@ -1,0 +1,107 @@
+import { getTestMode } from './config.js';
+import { getMaxPlaybookLevel, getPlayerBoxer } from './player-boxer.js';
+import { RULESETS } from './ruleset-data.js';
+import { SoundManager } from './sound-manager.js';
+
+export class MatchSetupScene extends Phaser.Scene {
+  constructor() {
+    super('MatchSetup');
+  }
+
+  create() {
+    const width = this.sys.game.config.width;
+    const height = this.sys.game.config.height;
+    const testMode = getTestMode();
+    const boxer1 = getPlayerBoxer();
+    const maxLevel = getMaxPlaybookLevel(boxer1);
+    const plans1 = Object.values(RULESETS).filter(
+      (p) => !p.perk || boxer1?.perks?.some((r) => r.Name === p.perk)
+    );
+    const plans2 = Object.values(RULESETS);
+
+    const optionsHtml = `
+      <div style="background:rgba(0,0,0,0.6);padding:20px;color:#fff;display:flex;flex-direction:column;gap:20px;min-width:400px;">
+        <div>
+          <span>Control:</span>
+          <label><input type="radio" name="control" value="ai" checked> Computer</label>
+          <label style="margin-left:40px;"><input type="radio" name="control" value="human"> Keyboard</label>
+        </div>
+        <div id="pb1">
+          <div>Playbook level: <span id="pb1_val">1</span></div>
+          <input id="pb1_slider" type="range" min="1" max="${maxLevel}" value="1" />
+          <div>Fight plan:
+            <select id="fp1_sel">
+              ${plans1.map((p) => `<option value="${p.id}">${p.name}</option>`).join('')}
+            </select>
+          </div>
+        </div>
+        ${testMode ? `
+        <div id="pb2">
+          <div>Playbook level boxer2: <span id="pb2_val">1</span></div>
+          <input id="pb2_slider" type="range" min="1" max="10" value="1" />
+          <div>Fight plan:
+            <select id="fp2_sel">
+              ${plans2.map((p) => `<option value="${p.id}">${p.name}</option>`).join('')}
+            </select>
+          </div>
+        </div>` : ''}
+        <div>
+          <div>Rounds: <span id="round_val">1</span></div>
+          <input id="round_slider" type="range" min="1" max="13" value="1" />
+        </div>
+        <button id="next_btn">Select boxer</button>
+      </div>
+    `;
+    const dom = this.add.dom(width / 2, height / 2).createFromHTML(optionsHtml);
+    dom.setOrigin(0.5);
+    const controlRadios = dom.node.querySelectorAll('input[name="control"]');
+    const pb1Div = dom.getChildByID('pb1');
+    controlRadios.forEach((r) => {
+      r.addEventListener('change', () => {
+        pb1Div.style.display = r.value === 'ai' ? 'block' : 'none';
+      });
+    });
+
+    const pb1Slider = dom.getChildByID('pb1_slider');
+    const pb1Val = dom.getChildByID('pb1_val');
+    if (pb1Slider) {
+      pb1Slider.addEventListener('input', () => {
+        pb1Val.textContent = pb1Slider.value;
+      });
+    }
+
+    const pb2Slider = dom.getChildByID('pb2_slider');
+    const pb2Val = dom.getChildByID('pb2_val');
+    if (pb2Slider) {
+      pb2Slider.addEventListener('input', () => {
+        pb2Val.textContent = pb2Slider.value;
+      });
+    }
+
+    const roundSlider = dom.getChildByID('round_slider');
+    const roundVal = dom.getChildByID('round_val');
+    roundSlider.addEventListener('input', () => {
+      roundVal.textContent = roundSlider.value;
+    });
+
+    const nextBtn = dom.getChildByID('next_btn');
+    nextBtn.addEventListener('click', () => {
+      SoundManager.playClick();
+      const control = dom.node.querySelector('input[name="control"]:checked').value;
+      const playbook1 = control === 'human' ? 'default' : pb1Slider.value;
+      const fightPlan1 = control === 'human' ? 'default' : dom.getChildByID('fp1_sel').value;
+      const playbook2 = testMode ? pb2Slider.value : 'default';
+      const fightPlan2 = testMode ? dom.getChildByID('fp2_sel').value : 'default';
+      const rounds = parseInt(roundSlider.value, 10) || 1;
+      dom.destroy();
+      this.scene.start('SelectBoxer', {
+        isBoxer1Human: control === 'human',
+        playbook1,
+        fightPlan1,
+        playbook2,
+        fightPlan2,
+        rounds,
+      });
+    });
+  }
+}

--- a/src/scripts/ranking-scene.js
+++ b/src/scripts/ranking-scene.js
@@ -277,7 +277,7 @@ export class RankingScene extends Phaser.Scene {
     } else {
       const btnY = tableBottom + 50;
       const goToSetup = () => {
-        this.scene.start('SelectBoxer');
+        this.scene.start('MatchSetup');
       };
       createGloveButton(this, width / 2, btnY, 'Next fight', goToSetup);
       this.input.keyboard.on('keydown-ENTER', goToSetup);

--- a/src/scripts/select-boxer-scene.js
+++ b/src/scripts/select-boxer-scene.js
@@ -1,68 +1,26 @@
-import { getRankings, getMatchPreview } from './boxer-stats.js';
+import { getRankings } from './boxer-stats.js';
 import { getTestMode, tableAlpha } from './config.js';
-import { getPlayerBoxer, getMaxPlaybookLevel } from './player-boxer.js';
+import { getPlayerBoxer } from './player-boxer.js';
 import { SoundManager } from './sound-manager.js';
 import { scheduleMatch, getPendingMatch } from './next-match.js';
-import { createPlaybookLevelSelector, createRoundSelector } from './UIDialogControls.js';
-import { createGloveButton } from './glove-button.js';
-import { RULESETS } from './ruleset-data.js';
 
 export class SelectBoxerScene extends Phaser.Scene {
   constructor() {
     super('SelectBoxer');
-    this.step = 1;
-    this.choice = [];
     this.options = [];
+    this.choice = [];
     this.filterText = '';
-    this.selectedPlaybook1 = null;
-    this.selectedPlaybook2 = null;
-    this.selectedFightPlan1 = null;
-    this.selectedFightPlan2 = null;
-    this.isBoxer1Human = false;
-    this.selectedRounds = null;
+    this.setup = {};
   }
 
-  create() {
+  create(data) {
+    this.setup = data || {};
     const width = this.sys.game.config.width;
     const height = this.sys.game.config.height;
+
     this.instruction = this.add
-      .text(20, 20, '', {
-        font: '24px Arial',
-        color: '#ffffff',
-      })
+      .text(20, 20, '', { font: '24px Arial', color: '#ffffff' })
       .setOrigin(0, 0);
-
-    if (getTestMode()) {
-      // checkbox to toggle human control for boxer1 in test mode
-      const cbX = width - 250;
-      this.humanBox = this.add
-        .rectangle(cbX, 25, 20, 20, 0xffffff)
-        .setOrigin(0, 0)
-        .setInteractive({ useHandCursor: true });
-      this.humanCheck = this.add
-        .text(cbX + 10, 25, 'X', {
-          font: '20px Arial',
-          color: '#000000',
-        })
-        .setOrigin(0.5, 0)
-        .setVisible(this.isBoxer1Human);
-      this.add
-        .text(cbX + 30, 20, 'Human Controlled', {
-          font: '20px Arial',
-          color: '#ffffff',
-        })
-        .setOrigin(0, 0);
-      this.humanBox.on('pointerdown', () => {
-        this.isBoxer1Human = !this.isBoxer1Human;
-        this.humanCheck.setVisible(this.isBoxer1Human);
-      });
-    }
-
-    // When returning to this scene (e.g. after a match) the previous
-    // selection state may still linger because the scene instance is
-    // reused.  Reset everything so that the boxer options can be
-    // selected again.
-    this.resetSelection();
 
     const back = () => {
       this.scene.start('Ranking');
@@ -72,15 +30,34 @@ export class SelectBoxerScene extends Phaser.Scene {
       .setInteractive({ useHandCursor: true })
       .on('pointerdown', back);
     this.input.keyboard.on('keydown-BACKSPACE', back);
+
+    this.resetSelection();
+  }
+
+  resetSelection() {
+    this.choice = [];
+    this.filterText = '';
+    if (!getTestMode()) {
+      const player = getPlayerBoxer();
+      if (player) this.choice = [player];
+      this.instruction.setText('Choose your opponent');
+    } else {
+      this.instruction.setText('Choose first boxer');
+    }
+    this.showBoxerOptions();
   }
 
   showBoxerOptions() {
     this.clearOptions();
     const width = this.sys.game.config.width;
     const filter = (this.filterText || '').toLowerCase();
-    const boxers = getRankings().filter((b) =>
-      b.name.toLowerCase().includes(filter)
-    );
+    const player = getPlayerBoxer();
+    const selectedIds = this.choice.map((c) => c.id);
+    const boxers = getRankings().filter((b) => {
+      if (!getTestMode() && b === player) return false;
+      if (selectedIds.includes(b.id)) return false;
+      return b.name.toLowerCase().includes(filter);
+    });
     const maxNameLen = boxers.reduce((m, b) => Math.max(m, b.name.length), 4);
     const columnWidths = [5, Math.max(15, maxNameLen + 1), 5, 5, 5, 5, 5, 5];
     const charWidth = 12;
@@ -148,169 +125,6 @@ export class SelectBoxerScene extends Phaser.Scene {
     });
   }
 
-  showPlaybookOptions(maxLevel) {
-    this.clearOptions();
-    const boxer = this.choice[this.choice.length - 1];
-    const availablePlans = Object.values(RULESETS).filter(
-      (p) => !p.perk || boxer.perks?.some((r) => r.Name === p.perk)
-    );
-    const dom = createPlaybookLevelSelector(this, {
-      maxLevel,
-      start: boxer?.defaultPlaybook || 1,
-      fightPlans: availablePlans,
-      startFightPlan: boxer.ruleset,
-      defaultFightPlan: boxer.ruleset,
-      onSelect: (sel) => {
-        this.options = (this.options || []).filter((o) => o !== dom);
-        this.selectPlaybook(sel);
-      },
-    });
-    (this.options ||= []).push(dom);
-  }
-
-  showControlOptions() {
-    this.clearOptions();
-    const width = this.sys.game.config.width;
-    const height = this.sys.game.config.height;
-    const spacing = 40;
-    const startX = (width - (300 * 2 + spacing)) / 2 + 150;
-    const centerY = height * 0.4;
-
-    const makeOption = (x, label, icon, handler) => {
-      const container = this.add.container(x, centerY);
-      const bg = this.add.rectangle(0, 0, 300, 200, 0x001b44, 0.4);
-      const img = this.add.image(0, -30, icon).setDisplaySize(128, 128);
-      const txt = this.add
-        .text(0, 70, label, { font: '32px Arial', color: '#ffffff' })
-        .setOrigin(0.5);
-      container.add([bg, img, txt]);
-      container.setSize(300, 200);
-      container.setInteractive({ useHandCursor: true });
-      container.on('pointerdown', handler);
-      this.options.push(container);
-    };
-
-    makeOption(startX, 'Computer', 'computer', () => this.selectControl('ai'));
-    makeOption(startX + 300 + spacing, 'Keyboard', 'keyboard', () =>
-      this.selectControl('human')
-    );
-  }
-
-  showOpponentOptions() {
-    this.clearOptions();
-    const width = this.sys.game.config.width;
-    const allBoxers = getRankings();
-    const maxNameLen = allBoxers.reduce((m, b) => Math.max(m, b.name.length), 4);
-    const namePad = Math.max(15, maxNameLen + 1);
-    const maxRegionLen = allBoxers.reduce(
-      (m, b) => Math.max(m, (b.continent || '').length),
-      0
-    );
-    const regionPad = Math.max(14, maxRegionLen + 1);
-    const rectWidth = width * 0.9;
-    const charWidth = 12;
-    const totalChars = Math.floor(rectWidth / charWidth);
-    const baseWidths = [5, namePad, regionPad, 5, 5, 5, 5, 5, 5, 10];
-    const baseWidth = baseWidths.reduce((sum, w) => sum + w, 0);
-    const titlePad = Math.max(totalChars - baseWidth, 20);
-    const columnWidths = [
-      baseWidths[0],
-      baseWidths[1],
-      baseWidths[2],
-      baseWidths[3],
-      baseWidths[4],
-      baseWidths[5],
-      baseWidths[6],
-      baseWidths[7],
-      baseWidths[8],
-      titlePad,
-      baseWidths[9],
-    ];
-    const rowHeight = 24;
-    const tableLeft = width * 0.05;
-    this.options.push(
-      this.add
-        .rectangle(tableLeft, 60, rectWidth, rowHeight, 0x001b44, tableAlpha)
-        .setOrigin(0, 0)
-    );
-    const headers =
-      `${'Rank'.padEnd(columnWidths[0])}` +
-      `${'Name'.padEnd(columnWidths[1])}` +
-      `${'Region'.padEnd(columnWidths[2])}` +
-      `${'Age'.padEnd(columnWidths[3])}` +
-      `${'M'.padEnd(columnWidths[4])}` +
-      `${'W'.padEnd(columnWidths[5])}` +
-      `${'L'.padEnd(columnWidths[6])}` +
-      `${'D'.padEnd(columnWidths[7])}` +
-      `${'KO'.padEnd(columnWidths[8])}` +
-      `${'Titles'.padEnd(columnWidths[9])}` +
-      `${'Title bout'.padEnd(columnWidths[10])}`;
-    const headerText = this.add.text(tableLeft, 60, headers, {
-      font: '20px monospace',
-      color: '#ffff00',
-    });
-    this.options.push(headerText);
-    const player = getPlayerBoxer();
-    // Limit the number of higher-ranked opponents to at most three.
-    const above = allBoxers
-      .filter((b) => b.ranking < player.ranking)
-      .slice(-3);
-    const belowOrEqual = allBoxers.filter((b) => b.ranking >= player.ranking);
-    const boxers = above.concat(belowOrEqual);
-    boxers.forEach((b, i) => {
-      const y = 80 + i * 24;
-      this.options.push(
-        this.add
-          .rectangle(tableLeft, y, rectWidth, rowHeight, 0x001b44, tableAlpha)
-          .setOrigin(0, 0)
-      );
-      const titlesStr = b.titles
-        ? b.titles.map((t) => `${t}🏆`).join(' ')
-        : '';
-      const isPlayer = b === player;
-      const preview = !isPlayer ? getMatchPreview(player, b) : null;
-      const isTitleBout = preview && preview.titlesOnTheLine.length > 0;
-      const line =
-        `${b.ranking.toString().padEnd(columnWidths[0])}` +
-        `${b.name.padEnd(columnWidths[1])}` +
-        `${(b.continent || '').padEnd(columnWidths[2])}` +
-        `${b.age.toString().padEnd(columnWidths[3])}` +
-        `${b.matches.toString().padEnd(columnWidths[4])}` +
-        `${b.wins.toString().padEnd(columnWidths[5])}` +
-        `${b.losses.toString().padEnd(columnWidths[6])}` +
-        `${b.draws.toString().padEnd(columnWidths[7])}` +
-        `${b.winsByKO.toString().padEnd(columnWidths[8])}` +
-        `${titlesStr.padEnd(columnWidths[9])}` +
-        `${(isTitleBout ? 'Yes' : '').padEnd(columnWidths[10])}`;
-      const txt = this.add.text(tableLeft, y, line, {
-        font: '20px monospace',
-        color: isPlayer ? '#404040' : '#ffffff',
-        fontStyle: isPlayer ? 'bold' : 'normal',
-      });
-      if (!isPlayer) {
-        txt.setInteractive({ useHandCursor: true });
-        txt.on('pointerdown', () => this.selectBoxer(b));
-      }
-      this.options.push(txt);
-    });
-  }
-
-  selectControl(mode) {
-    SoundManager.playClick();
-    this.isBoxer1Human = mode === 'human';
-    if (this.isBoxer1Human) {
-      this.selectedPlaybook1 = 'default';
-      this.selectedFightPlan1 = 'default';
-      this.step = 2;
-      this.instruction.setText('Choose your opponent');
-      this.showOpponentOptions();
-    } else {
-      this.step = 1;
-      this.instruction.setText('Choose Player 1 playbook');
-      this.showPlaybookOptions(getMaxPlaybookLevel());
-    }
-  }
-
   clearOptions() {
     this.options.forEach((o) => {
       if (o && !o.destroyed) {
@@ -322,128 +136,30 @@ export class SelectBoxerScene extends Phaser.Scene {
 
   selectBoxer(boxer) {
     SoundManager.playClick();
-    if (!getTestMode() && this.step === 2) {
-      this.choice.push(boxer);
-      this.selectedPlaybook2 = 'default';
-      this.selectedFightPlan2 = 'default';
-      this.step = 3;
-      this.showRoundOptions();
-      return;
-    }
-
     this.choice.push(boxer);
-    if (this.step === 1) {
-      if (this.humanBox) this.humanBox.disableInteractive();
-      if (this.isBoxer1Human) {
-        this.step = 3;
-        this.instruction.setText('Choose your opponent');
-      } else {
-        if (getTestMode()) {
-          this.step = 2;
-          this.instruction.setText('Choose Player 1 playbook');
-          this.showPlaybookOptions(10);
-        } else {
-          this.selectedPlaybook1 = 'default';
-          this.selectedFightPlan1 = 'default';
-          this.step = 2;
-          this.instruction.setText('Choose your opponent');
-          this.showOpponentOptions();
-        }
-      }
-    } else if (this.step === 3) {
-      if (getTestMode()) {
-        this.step = 4;
-        this.instruction.setText("Choose the opponent's playbook");
-        this.showPlaybookOptions(10);
-      } else {
-        this.selectedPlaybook2 = 'default';
-        this.selectedFightPlan2 = 'default';
-        this.step = 5;
-        this.showRoundOptions();
+    if (getTestMode()) {
+      if (this.choice.length < 2) {
+        this.instruction.setText('Choose second boxer');
+        this.showBoxerOptions();
+        return;
       }
     }
-  }
-
-  selectPlaybook({ level, fightPlan }) {
-    SoundManager.playClick();
-    if (this.step === 1) {
-      // non-test mode: player playbook selection
-      this.selectedPlaybook1 = level;
-      this.selectedFightPlan1 = fightPlan;
-      this.step = 2;
-      this.instruction.setText('Choose your opponent');
-      this.showOpponentOptions();
-    } else if (this.step === 2) {
-      // test mode: player playbook selection
-      this.selectedPlaybook1 = level;
-      this.selectedFightPlan1 = fightPlan;
-      this.step = 3;
-      this.instruction.setText('Choose your opponent');
-      this.showBoxerOptions();
-    } else if (this.step === 4) {
-      // test mode: opponent playbook selection
-      this.selectedPlaybook2 = level;
-      this.selectedFightPlan2 = fightPlan;
-      this.step = 5;
-      this.showRoundOptions();
+    const [boxer1, boxer2] = getTestMode() ? this.choice : [this.choice[0], boxer];
+    if (this.setup.fightPlan1 && this.setup.fightPlan1 !== 'default') {
+      boxer1.ruleset = this.setup.fightPlan1;
     }
-  }
-
-  showRoundOptions(maxRounds = 13) {
-    this.clearOptions();
-    this.instruction.setText(`Choose number of rounds (1-${maxRounds})`);
-    const dom = createRoundSelector(this, {
-      maxRounds,
-      onSelect: (val) => this.selectRounds(val),
-    });
-    this.options.push(dom);
-  }
-
-  selectRounds(num) {
-    this.selectedRounds = num;
-    const [boxer1, boxer2] = this.choice;
-    if (this.selectedFightPlan1 && this.selectedFightPlan1 !== 'default') {
-      boxer1.ruleset = this.selectedFightPlan1;
+    if (this.setup.fightPlan2 && this.setup.fightPlan2 !== 'default') {
+      boxer2.ruleset = this.setup.fightPlan2;
     }
-    if (this.selectedFightPlan2 && this.selectedFightPlan2 !== 'default') {
-      boxer2.ruleset = this.selectedFightPlan2;
-    }
-    const rounds = this.selectedRounds ?? 1;
-    const aiLevel1 = this.isBoxer1Human
-      ? null
-      : this.selectedPlaybook1 ?? 'default';
-    const aiLevel2 = this.selectedPlaybook2 ?? 'default';
+    const rounds = this.setup.rounds ?? 1;
+    const aiLevel1 = this.setup.isBoxer1Human ? null : this.setup.playbook1 ?? 'default';
+    const aiLevel2 = this.setup.playbook2 ?? 'default';
     scheduleMatch({ boxer1, boxer2, aiLevel1, aiLevel2, rounds });
     const pending = getPendingMatch();
     if (pending) {
-      // Go to calendar to simulate other matches before the player's fight
       this.scene.start('Calendar');
     } else {
       this.scene.start('Ranking');
     }
   }
-
-  resetSelection() {
-    this.choice = [];
-    this.selectedPlaybook1 = null;
-    this.selectedPlaybook2 = null;
-    this.selectedFightPlan1 = null;
-    this.selectedFightPlan2 = null;
-    this.selectedRounds = null;
-    this.isBoxer1Human = false;
-    this.filterText = '';
-    if (!getTestMode() && getPlayerBoxer()) {
-      this.choice = [getPlayerBoxer()];
-      this.step = 0;
-      this.instruction.setText('Choose control method');
-      this.showControlOptions();
-    } else {
-      this.step = 1;
-      if (this.humanCheck) this.humanCheck.setVisible(false);
-      if (this.humanBox) this.humanBox.setInteractive({ useHandCursor: true });
-      this.instruction.setText('Choose your boxer');
-      this.showBoxerOptions();
-    }
-  }
-
 }

--- a/src/scripts/select-boxer-scene_obsolte.js
+++ b/src/scripts/select-boxer-scene_obsolte.js
@@ -1,0 +1,451 @@
+/* Obsolete scene - code commented out
+import { getRankings, getMatchPreview } from './boxer-stats.js';
+import { getTestMode, tableAlpha } from './config.js';
+import { getPlayerBoxer, getMaxPlaybookLevel } from './player-boxer.js';
+import { SoundManager } from './sound-manager.js';
+import { scheduleMatch, getPendingMatch } from './next-match.js';
+import { createPlaybookLevelSelector, createRoundSelector } from './UIDialogControls.js';
+import { createGloveButton } from './glove-button.js';
+import { RULESETS } from './ruleset-data.js';
+
+export class SelectBoxerScene extends Phaser.Scene {
+  constructor() {
+    super('SelectBoxer');
+    this.step = 1;
+    this.choice = [];
+    this.options = [];
+    this.filterText = '';
+    this.selectedPlaybook1 = null;
+    this.selectedPlaybook2 = null;
+    this.selectedFightPlan1 = null;
+    this.selectedFightPlan2 = null;
+    this.isBoxer1Human = false;
+    this.selectedRounds = null;
+  }
+
+  create() {
+    const width = this.sys.game.config.width;
+    const height = this.sys.game.config.height;
+    this.instruction = this.add
+      .text(20, 20, '', {
+        font: '24px Arial',
+        color: '#ffffff',
+      })
+      .setOrigin(0, 0);
+
+    if (getTestMode()) {
+      // checkbox to toggle human control for boxer1 in test mode
+      const cbX = width - 250;
+      this.humanBox = this.add
+        .rectangle(cbX, 25, 20, 20, 0xffffff)
+        .setOrigin(0, 0)
+        .setInteractive({ useHandCursor: true });
+      this.humanCheck = this.add
+        .text(cbX + 10, 25, 'X', {
+          font: '20px Arial',
+          color: '#000000',
+        })
+        .setOrigin(0.5, 0)
+        .setVisible(this.isBoxer1Human);
+      this.add
+        .text(cbX + 30, 20, 'Human Controlled', {
+          font: '20px Arial',
+          color: '#ffffff',
+        })
+        .setOrigin(0, 0);
+      this.humanBox.on('pointerdown', () => {
+        this.isBoxer1Human = !this.isBoxer1Human;
+        this.humanCheck.setVisible(this.isBoxer1Human);
+      });
+    }
+
+    // When returning to this scene (e.g. after a match) the previous
+    // selection state may still linger because the scene instance is
+    // reused.  Reset everything so that the boxer options can be
+    // selected again.
+    this.resetSelection();
+
+    const back = () => {
+      this.scene.start('Ranking');
+    };
+    this.add
+      .text(20, height - 40, 'Back', { font: '24px Arial', color: '#ffff00' })
+      .setInteractive({ useHandCursor: true })
+      .on('pointerdown', back);
+    this.input.keyboard.on('keydown-BACKSPACE', back);
+  }
+
+  showBoxerOptions() {
+    this.clearOptions();
+    const width = this.sys.game.config.width;
+    const filter = (this.filterText || '').toLowerCase();
+    const boxers = getRankings().filter((b) =>
+      b.name.toLowerCase().includes(filter)
+    );
+    const maxNameLen = boxers.reduce((m, b) => Math.max(m, b.name.length), 4);
+    const columnWidths = [5, Math.max(15, maxNameLen + 1), 5, 5, 5, 5, 5, 5];
+    const charWidth = 12;
+    const rectWidth = columnWidths.reduce((a, c) => a + c, 0) * charWidth;
+    const tableLeft = (width - rectWidth) / 2;
+    const rowHeight = 24;
+    const filterDom = this.add
+      .dom(width - 220, 20)
+      .createFromHTML(
+        `<input type="text" placeholder="Filter boxers" style="width:200px;padding:4px;font-size:16px;" />`
+      );
+    filterDom.setOrigin(0, 0);
+    const filterEl =
+      filterDom.node.tagName === 'INPUT' ? filterDom.node : filterDom.node.querySelector('input');
+    if (filterEl) {
+      filterEl.value = this.filterText;
+      filterEl.addEventListener('input', () => {
+        this.filterText = filterEl.value;
+        this.showBoxerOptions();
+      });
+    }
+    this.options.push(filterDom);
+    this.options.push(
+      this.add
+        .rectangle(width / 2, 60, rectWidth, rowHeight, 0x001b44, tableAlpha)
+        .setOrigin(0.5, 0)
+    );
+    const headers =
+      `${'Rank'.padEnd(columnWidths[0])}` +
+      `${'Name'.padEnd(columnWidths[1])}` +
+      `${'Age'.padEnd(columnWidths[2])}` +
+      `${'M'.padEnd(columnWidths[3])}` +
+      `${'W'.padEnd(columnWidths[4])}` +
+      `${'L'.padEnd(columnWidths[5])}` +
+      `${'D'.padEnd(columnWidths[6])}` +
+      `${'KO'.padEnd(columnWidths[7])}`;
+    const headerText = this.add.text(tableLeft, 60, headers, {
+      font: '20px monospace',
+      color: '#ffff00',
+    });
+    this.options.push(headerText);
+    boxers.forEach((b, i) => {
+      const y = 80 + i * 24;
+      this.options.push(
+        this.add
+          .rectangle(width / 2, y, rectWidth, rowHeight, 0x001b44, tableAlpha)
+          .setOrigin(0.5, 0)
+      );
+      const line =
+        `${b.ranking.toString().padEnd(columnWidths[0])}` +
+        `${b.name.padEnd(columnWidths[1])}` +
+        `${b.age.toString().padEnd(columnWidths[2])}` +
+        `${b.matches.toString().padEnd(columnWidths[3])}` +
+        `${b.wins.toString().padEnd(columnWidths[4])}` +
+        `${b.losses.toString().padEnd(columnWidths[5])}` +
+        `${b.draws.toString().padEnd(columnWidths[6])}` +
+        `${b.winsByKO.toString().padEnd(columnWidths[7])}`;
+      const txt = this.add.text(tableLeft, y, line, {
+        font: '20px monospace',
+        color: '#ffffff',
+      });
+      txt.setInteractive({ useHandCursor: true });
+      txt.on('pointerdown', () => this.selectBoxer(b));
+      this.options.push(txt);
+    });
+  }
+
+  showPlaybookOptions(maxLevel) {
+    this.clearOptions();
+    const boxer = this.choice[this.choice.length - 1];
+    const availablePlans = Object.values(RULESETS).filter(
+      (p) => !p.perk || boxer.perks?.some((r) => r.Name === p.perk)
+    );
+    const dom = createPlaybookLevelSelector(this, {
+      maxLevel,
+      start: boxer?.defaultPlaybook || 1,
+      fightPlans: availablePlans,
+      startFightPlan: boxer.ruleset,
+      defaultFightPlan: boxer.ruleset,
+      onSelect: (sel) => {
+        this.options = (this.options || []).filter((o) => o !== dom);
+        this.selectPlaybook(sel);
+      },
+    });
+    (this.options ||= []).push(dom);
+  }
+
+  showControlOptions() {
+    this.clearOptions();
+    const width = this.sys.game.config.width;
+    const height = this.sys.game.config.height;
+    const spacing = 40;
+    const startX = (width - (300 * 2 + spacing)) / 2 + 150;
+    const centerY = height * 0.4;
+
+    const makeOption = (x, label, icon, handler) => {
+      const container = this.add.container(x, centerY);
+      const bg = this.add.rectangle(0, 0, 300, 200, 0x001b44, 0.4);
+      const img = this.add.image(0, -30, icon).setDisplaySize(128, 128);
+      const txt = this.add
+        .text(0, 70, label, { font: '32px Arial', color: '#ffffff' })
+        .setOrigin(0.5);
+      container.add([bg, img, txt]);
+      container.setSize(300, 200);
+      container.setInteractive({ useHandCursor: true });
+      container.on('pointerdown', handler);
+      this.options.push(container);
+    };
+
+    makeOption(startX, 'Computer', 'computer', () => this.selectControl('ai'));
+    makeOption(startX + 300 + spacing, 'Keyboard', 'keyboard', () =>
+      this.selectControl('human')
+    );
+  }
+
+  showOpponentOptions() {
+    this.clearOptions();
+    const width = this.sys.game.config.width;
+    const allBoxers = getRankings();
+    const maxNameLen = allBoxers.reduce((m, b) => Math.max(m, b.name.length), 4);
+    const namePad = Math.max(15, maxNameLen + 1);
+    const maxRegionLen = allBoxers.reduce(
+      (m, b) => Math.max(m, (b.continent || '').length),
+      0
+    );
+    const regionPad = Math.max(14, maxRegionLen + 1);
+    const rectWidth = width * 0.9;
+    const charWidth = 12;
+    const totalChars = Math.floor(rectWidth / charWidth);
+    const baseWidths = [5, namePad, regionPad, 5, 5, 5, 5, 5, 5, 10];
+    const baseWidth = baseWidths.reduce((sum, w) => sum + w, 0);
+    const titlePad = Math.max(totalChars - baseWidth, 20);
+    const columnWidths = [
+      baseWidths[0],
+      baseWidths[1],
+      baseWidths[2],
+      baseWidths[3],
+      baseWidths[4],
+      baseWidths[5],
+      baseWidths[6],
+      baseWidths[7],
+      baseWidths[8],
+      titlePad,
+      baseWidths[9],
+    ];
+    const rowHeight = 24;
+    const tableLeft = width * 0.05;
+    this.options.push(
+      this.add
+        .rectangle(tableLeft, 60, rectWidth, rowHeight, 0x001b44, tableAlpha)
+        .setOrigin(0, 0)
+    );
+    const headers =
+      `${'Rank'.padEnd(columnWidths[0])}` +
+      `${'Name'.padEnd(columnWidths[1])}` +
+      `${'Region'.padEnd(columnWidths[2])}` +
+      `${'Age'.padEnd(columnWidths[3])}` +
+      `${'M'.padEnd(columnWidths[4])}` +
+      `${'W'.padEnd(columnWidths[5])}` +
+      `${'L'.padEnd(columnWidths[6])}` +
+      `${'D'.padEnd(columnWidths[7])}` +
+      `${'KO'.padEnd(columnWidths[8])}` +
+      `${'Titles'.padEnd(columnWidths[9])}` +
+      `${'Title bout'.padEnd(columnWidths[10])}`;
+    const headerText = this.add.text(tableLeft, 60, headers, {
+      font: '20px monospace',
+      color: '#ffff00',
+    });
+    this.options.push(headerText);
+    const player = getPlayerBoxer();
+    // Limit the number of higher-ranked opponents to at most three.
+    const above = allBoxers
+      .filter((b) => b.ranking < player.ranking)
+      .slice(-3);
+    const belowOrEqual = allBoxers.filter((b) => b.ranking >= player.ranking);
+    const boxers = above.concat(belowOrEqual);
+    boxers.forEach((b, i) => {
+      const y = 80 + i * 24;
+      this.options.push(
+        this.add
+          .rectangle(tableLeft, y, rectWidth, rowHeight, 0x001b44, tableAlpha)
+          .setOrigin(0, 0)
+      );
+      const titlesStr = b.titles
+        ? b.titles.map((t) => `${t}🏆`).join(' ')
+        : '';
+      const isPlayer = b === player;
+      const preview = !isPlayer ? getMatchPreview(player, b) : null;
+      const isTitleBout = preview && preview.titlesOnTheLine.length > 0;
+      const line =
+        `${b.ranking.toString().padEnd(columnWidths[0])}` +
+        `${b.name.padEnd(columnWidths[1])}` +
+        `${(b.continent || '').padEnd(columnWidths[2])}` +
+        `${b.age.toString().padEnd(columnWidths[3])}` +
+        `${b.matches.toString().padEnd(columnWidths[4])}` +
+        `${b.wins.toString().padEnd(columnWidths[5])}` +
+        `${b.losses.toString().padEnd(columnWidths[6])}` +
+        `${b.draws.toString().padEnd(columnWidths[7])}` +
+        `${b.winsByKO.toString().padEnd(columnWidths[8])}` +
+        `${titlesStr.padEnd(columnWidths[9])}` +
+        `${(isTitleBout ? 'Yes' : '').padEnd(columnWidths[10])}`;
+      const txt = this.add.text(tableLeft, y, line, {
+        font: '20px monospace',
+        color: isPlayer ? '#404040' : '#ffffff',
+        fontStyle: isPlayer ? 'bold' : 'normal',
+      });
+      if (!isPlayer) {
+        txt.setInteractive({ useHandCursor: true });
+        txt.on('pointerdown', () => this.selectBoxer(b));
+      }
+      this.options.push(txt);
+    });
+  }
+
+  selectControl(mode) {
+    SoundManager.playClick();
+    this.isBoxer1Human = mode === 'human';
+    if (this.isBoxer1Human) {
+      this.selectedPlaybook1 = 'default';
+      this.selectedFightPlan1 = 'default';
+      this.step = 2;
+      this.instruction.setText('Choose your opponent');
+      this.showOpponentOptions();
+    } else {
+      this.step = 1;
+      this.instruction.setText('Choose Player 1 playbook');
+      this.showPlaybookOptions(getMaxPlaybookLevel());
+    }
+  }
+
+  clearOptions() {
+    this.options.forEach((o) => {
+      if (o && !o.destroyed) {
+        o.destroy();
+      }
+    });
+    this.options = [];
+  }
+
+  selectBoxer(boxer) {
+    SoundManager.playClick();
+    if (!getTestMode() && this.step === 2) {
+      this.choice.push(boxer);
+      this.selectedPlaybook2 = 'default';
+      this.selectedFightPlan2 = 'default';
+      this.step = 3;
+      this.showRoundOptions();
+      return;
+    }
+
+    this.choice.push(boxer);
+    if (this.step === 1) {
+      if (this.humanBox) this.humanBox.disableInteractive();
+      if (this.isBoxer1Human) {
+        this.step = 3;
+        this.instruction.setText('Choose your opponent');
+      } else {
+        if (getTestMode()) {
+          this.step = 2;
+          this.instruction.setText('Choose Player 1 playbook');
+          this.showPlaybookOptions(10);
+        } else {
+          this.selectedPlaybook1 = 'default';
+          this.selectedFightPlan1 = 'default';
+          this.step = 2;
+          this.instruction.setText('Choose your opponent');
+          this.showOpponentOptions();
+        }
+      }
+    } else if (this.step === 3) {
+      if (getTestMode()) {
+        this.step = 4;
+        this.instruction.setText("Choose the opponent's playbook");
+        this.showPlaybookOptions(10);
+      } else {
+        this.selectedPlaybook2 = 'default';
+        this.selectedFightPlan2 = 'default';
+        this.step = 5;
+        this.showRoundOptions();
+      }
+    }
+  }
+
+  selectPlaybook({ level, fightPlan }) {
+    SoundManager.playClick();
+    if (this.step === 1) {
+      // non-test mode: player playbook selection
+      this.selectedPlaybook1 = level;
+      this.selectedFightPlan1 = fightPlan;
+      this.step = 2;
+      this.instruction.setText('Choose your opponent');
+      this.showOpponentOptions();
+    } else if (this.step === 2) {
+      // test mode: player playbook selection
+      this.selectedPlaybook1 = level;
+      this.selectedFightPlan1 = fightPlan;
+      this.step = 3;
+      this.instruction.setText('Choose your opponent');
+      this.showBoxerOptions();
+    } else if (this.step === 4) {
+      // test mode: opponent playbook selection
+      this.selectedPlaybook2 = level;
+      this.selectedFightPlan2 = fightPlan;
+      this.step = 5;
+      this.showRoundOptions();
+    }
+  }
+
+  showRoundOptions(maxRounds = 13) {
+    this.clearOptions();
+    this.instruction.setText(`Choose number of rounds (1-${maxRounds})`);
+    const dom = createRoundSelector(this, {
+      maxRounds,
+      onSelect: (val) => this.selectRounds(val),
+    });
+    this.options.push(dom);
+  }
+
+  selectRounds(num) {
+    this.selectedRounds = num;
+    const [boxer1, boxer2] = this.choice;
+    if (this.selectedFightPlan1 && this.selectedFightPlan1 !== 'default') {
+      boxer1.ruleset = this.selectedFightPlan1;
+    }
+    if (this.selectedFightPlan2 && this.selectedFightPlan2 !== 'default') {
+      boxer2.ruleset = this.selectedFightPlan2;
+    }
+    const rounds = this.selectedRounds ?? 1;
+    const aiLevel1 = this.isBoxer1Human
+      ? null
+      : this.selectedPlaybook1 ?? 'default';
+    const aiLevel2 = this.selectedPlaybook2 ?? 'default';
+    scheduleMatch({ boxer1, boxer2, aiLevel1, aiLevel2, rounds });
+    const pending = getPendingMatch();
+    if (pending) {
+      // Go to calendar to simulate other matches before the player's fight
+      this.scene.start('Calendar');
+    } else {
+      this.scene.start('Ranking');
+    }
+  }
+
+  resetSelection() {
+    this.choice = [];
+    this.selectedPlaybook1 = null;
+    this.selectedPlaybook2 = null;
+    this.selectedFightPlan1 = null;
+    this.selectedFightPlan2 = null;
+    this.selectedRounds = null;
+    this.isBoxer1Human = false;
+    this.filterText = '';
+    if (!getTestMode() && getPlayerBoxer()) {
+      this.choice = [getPlayerBoxer()];
+      this.step = 0;
+      this.instruction.setText('Choose control method');
+      this.showControlOptions();
+    } else {
+      this.step = 1;
+      if (this.humanCheck) this.humanCheck.setVisible(false);
+      if (this.humanBox) this.humanBox.setInteractive({ useHandCursor: true });
+      this.instruction.setText('Choose your boxer');
+      this.showBoxerOptions();
+    }
+  }
+
+}
+*/


### PR DESCRIPTION
## Summary
- add MatchSetupScene to choose control type, playbooks, and rounds in one view
- simplify SelectBoxerScene to only pick boxers and schedule matches
- update ranking flow to launch new setup scene and register it in game config

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689cdc8c4e20832a8ba905827875de19