### PR TITLE
Improve match setup controls and boxer filtering

### DIFF
--- a/src/scripts/match-setup-scene.js
+++ b/src/scripts/match-setup-scene.js
@@ -2,6 +2,7 @@ import { getTestMode } from './config.js';
 import { getMaxPlaybookLevel, getPlayerBoxer } from './player-boxer.js';
 import { RULESETS } from './ruleset-data.js';
 import { SoundManager } from './sound-manager.js';
+import { createGloveButton } from './glove-button.js';
 
 export class MatchSetupScene extends Phaser.Scene {
   constructor() {
@@ -20,47 +21,57 @@ export class MatchSetupScene extends Phaser.Scene {
     const plans2 = Object.values(RULESETS);
 
     const optionsHtml = `
-      <div style="background:rgba(0,0,0,0.6);padding:20px;color:#fff;display:flex;flex-direction:column;gap:20px;min-width:400px;">
-        <div>
-          <span>Control:</span>
-          <label><input type="radio" name="control" value="ai" checked> Computer</label>
-          <label style="margin-left:40px;"><input type="radio" name="control" value="human"> Keyboard</label>
-        </div>
-        <div id="pb1">
-          <div>Playbook level: <span id="pb1_val">1</span></div>
-          <input id="pb1_slider" type="range" min="1" max="${maxLevel}" value="1" />
-          <div>Fight plan:
-            <select id="fp1_sel">
-              ${plans1.map((p) => `<option value="${p.id}">${p.name}</option>`).join('')}
-            </select>
+        <div style="background:rgba(0,0,0,0.6);padding:20px;color:#fff;display:flex;flex-direction:column;min-width:400px;">
+          <div style="display:flex;align-items:center;gap:20px;margin-bottom:10px;">
+            <img id="control_ai" src="assets/arena/computer.png" style="width:80px;height:80px;cursor:pointer;" />
+            <img id="control_human" src="assets/arena/keyboard.png" style="width:80px;height:80px;cursor:pointer;" />
+            <span id="control_label">Computer</span>
+          </div>
+          <div style="display:flex;flex-direction:column;gap:20px;">
+            <div id="pb1">
+              <div>Playbook level: <span id="pb1_val">1</span></div>
+              <input id="pb1_slider" type="range" min="1" max="${maxLevel}" value="1" />
+              <div>Fight plan:
+                <select id="fp1_sel">
+                  ${plans1.map((p) => `<option value="${p.id}">${p.name}</option>`).join('')}
+                </select>
+              </div>
+            </div>
+            ${testMode ? `
+            <div id="pb2">
+              <div>Playbook level boxer2: <span id="pb2_val">1</span></div>
+              <input id="pb2_slider" type="range" min="1" max="10" value="1" />
+              <div>Fight plan:
+                <select id="fp2_sel">
+                  ${plans2.map((p) => `<option value="${p.id}">${p.name}</option>`).join('')}
+                </select>
+              </div>
+            </div>` : ''}
+            <div>
+              <div>Rounds: <span id="round_val">1</span></div>
+              <input id="round_slider" type="range" min="1" max="13" value="1" />
+            </div>
           </div>
         </div>
-        ${testMode ? `
-        <div id="pb2">
-          <div>Playbook level boxer2: <span id="pb2_val">1</span></div>
-          <input id="pb2_slider" type="range" min="1" max="10" value="1" />
-          <div>Fight plan:
-            <select id="fp2_sel">
-              ${plans2.map((p) => `<option value="${p.id}">${p.name}</option>`).join('')}
-            </select>
-          </div>
-        </div>` : ''}
-        <div>
-          <div>Rounds: <span id="round_val">1</span></div>
-          <input id="round_slider" type="range" min="1" max="13" value="1" />
-        </div>
-        <button id="next_btn">Select boxer</button>
-      </div>
-    `;
-    const dom = this.add.dom(width / 2, height / 2).createFromHTML(optionsHtml);
-    dom.setOrigin(0.5);
-    const controlRadios = dom.node.querySelectorAll('input[name="control"]');
-    const pb1Div = dom.getChildByID('pb1');
-    controlRadios.forEach((r) => {
-      r.addEventListener('change', () => {
-        pb1Div.style.display = r.value === 'ai' ? 'block' : 'none';
+      `;
+      const dom = this.add.dom(width / 2, height / 2).createFromHTML(optionsHtml);
+      dom.setOrigin(0.5);
+
+      let control = 'ai';
+      const pb1Div = dom.getChildByID('pb1');
+      const controlLabel = dom.getChildByID('control_label');
+      const aiImg = dom.getChildByID('control_ai');
+      const humanImg = dom.getChildByID('control_human');
+      aiImg.addEventListener('click', () => {
+        control = 'ai';
+        controlLabel.textContent = 'Computer';
+        pb1Div.style.display = 'block';
       });
-    });
+      humanImg.addEventListener('click', () => {
+        control = 'human';
+        controlLabel.textContent = 'Keyboard';
+        pb1Div.style.display = 'none';
+      });
 
     const pb1Slider = dom.getChildByID('pb1_slider');
     const pb1Val = dom.getChildByID('pb1_val');
@@ -84,14 +95,12 @@ export class MatchSetupScene extends Phaser.Scene {
       roundVal.textContent = roundSlider.value;
     });
 
-    const nextBtn = dom.getChildByID('next_btn');
-    nextBtn.addEventListener('click', () => {
+    const proceed = () => {
       SoundManager.playClick();
-      const control = dom.node.querySelector('input[name="control"]:checked').value;
       const playbook1 = control === 'human' ? 'default' : pb1Slider.value;
       const fightPlan1 = control === 'human' ? 'default' : dom.getChildByID('fp1_sel').value;
-      const playbook2 = testMode ? pb2Slider.value : 'default';
-      const fightPlan2 = testMode ? dom.getChildByID('fp2_sel').value : 'default';
+      const playbook2 = testMode ? pb2Slider?.value : 'default';
+      const fightPlan2 = testMode ? dom.getChildByID('fp2_sel')?.value : 'default';
       const rounds = parseInt(roundSlider.value, 10) || 1;
       dom.destroy();
       this.scene.start('SelectBoxer', {
@@ -102,6 +111,17 @@ export class MatchSetupScene extends Phaser.Scene {
         fightPlan2,
         rounds,
       });
-    });
+    };
+    createGloveButton(this, width / 2, height - 80, 'Select boxer', proceed);
+
+    const back = () => {
+      dom.destroy();
+      this.scene.start('Ranking');
+    };
+    this.add
+      .text(20, height - 40, 'Back', { font: '24px Arial', color: '#ffff00' })
+      .setInteractive({ useHandCursor: true })
+      .on('pointerdown', back);
+    this.input.keyboard.on('keydown-BACKSPACE', back);
   }
 }

--- a/src/scripts/select-boxer-scene.js
+++ b/src/scripts/select-boxer-scene.js
@@ -52,12 +52,21 @@ export class SelectBoxerScene extends Phaser.Scene {
     const width = this.sys.game.config.width;
     const filter = (this.filterText || '').toLowerCase();
     const player = getPlayerBoxer();
-    const selectedIds = this.choice.map((c) => c.id);
-    const boxers = getRankings().filter((b) => {
+    const selectedNames = this.choice.map((c) => c.name);
+    let boxers = getRankings().filter((b) => {
       if (!getTestMode() && b === player) return false;
-      if (selectedIds.includes(b.id)) return false;
+      if (selectedNames.includes(b.name)) return false;
       return b.name.toLowerCase().includes(filter);
     });
+    if (!getTestMode() && player) {
+      const playerRank = player.ranking;
+      boxers = boxers.filter((b) => {
+        if (b.ranking < playerRank) {
+          return b.ranking >= playerRank - 3;
+        }
+        return true;
+      });
+    }
     const maxNameLen = boxers.reduce((m, b) => Math.max(m, b.name.length), 4);
     const columnWidths = [5, Math.max(15, maxNameLen + 1), 5, 5, 5, 5, 5, 5];
     const charWidth = 12;


### PR DESCRIPTION
## Summary
- Add top control box with computer/keyboard icons and glove button for proceeding in MatchSetupScene
- Include back navigation and swap radio buttons for image selection
- Fix boxer selection filtering to show 3 higher-ranked opponents and exclude already-chosen fighters

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689ce5349764832a87cde3465667a497