### PR TITLE
Clear bank transactions on data reset

### DIFF
--- a/src/scripts/bank-account.js
+++ b/src/scripts/bank-account.js
@@ -44,5 +44,10 @@ export function getBalance() {
 }
 
 export function resetBankAccount() {
-  saveTransactions([]);
+  if (typeof localStorage === 'undefined') return;
+  try {
+    localStorage.removeItem(BANK_KEY);
+  } catch (err) {
+    // ignore
+  }
 }

--- a/src/scripts/save-system.js
+++ b/src/scripts/save-system.js
@@ -160,7 +160,7 @@ export function resetSavedData() {
   setPlayerBoxer(null);
   resetMatchLog();
   resetDate();
-  resetBankAccount();
+  resetBankAccount(); // also clear stored bank transactions
 }
 
 // Placeholder for future migration logic.


### PR DESCRIPTION
## Summary
- Remove stored bank transactions when resetting data
- Document that data reset clears bank transactions

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689ce9adce4c832a80fc7b390a261691