### PR TITLE
Display boxer rankings and match titles

### DIFF
--- a/src/scripts/calendar-scene.js
+++ b/src/scripts/calendar-scene.js
@@ -101,7 +101,7 @@ export class CalendarScene extends Phaser.Scene {
       const y = startY + (i + 1) * rowH;
       const row = [];
       if (m.result) {
-        const resultLine = `${m.date} ${m.boxer1.name} vs ${m.boxer2.name} ${this.formatResult(
+        const resultLine = `${m.date} ${m.boxer1.name} (${m.boxer1.ranking}) vs ${m.boxer2.name} (${m.boxer2.ranking}) ${this.formatResult(
           m
         )}`;
         row.push(
@@ -119,12 +119,22 @@ export class CalendarScene extends Phaser.Scene {
       );
       row.push(
         this.add
-          .text(colX[1], y, m.boxer1.name, { font: '20px Arial', color: '#ffffff' })
+          .text(
+            colX[1],
+            y,
+            `${m.boxer1.name} (${m.boxer1.ranking})`,
+            { font: '20px Arial', color: '#ffffff' }
+          )
           .setOrigin(0.5, 0)
       );
       row.push(
         this.add
-          .text(colX[2], y, m.boxer2.name, { font: '20px Arial', color: '#ffffff' })
+          .text(
+            colX[2],
+            y,
+            `${m.boxer2.name} (${m.boxer2.ranking})`,
+            { font: '20px Arial', color: '#ffffff' }
+          )
           .setOrigin(0.5, 0)
       );
       const titles = Array.from(

--- a/src/scripts/match-scene.js
+++ b/src/scripts/match-scene.js
@@ -224,6 +224,10 @@ export class MatchScene extends Phaser.Scene {
       p1: data?.boxer1?.name || '',
       p2: data?.boxer2?.name || '',
     });
+    eventBus.emit('set-titles', {
+      p1: (data?.boxer1?.titles || []).map((t) => `${t}🏆`).join(' '),
+      p2: (data?.boxer2?.titles || []).map((t) => `${t}🏆`).join(' '),
+    });
     eventBus.emit('hit-update', { p1: 0, p2: 0 });
     eventBus.emit('score-update', { p1: 0, p2: 0 });
     this.events.on('boxer-ko', (b) => this.handleKO(b));

--- a/src/scripts/overlay.js
+++ b/src/scripts/overlay.js
@@ -102,6 +102,17 @@ export class OverlayUI extends Phaser.Scene {
       }),
     };
 
+    this.titleText = {
+      p1: this.add.text(20, infoY + 110, '', {
+        font: '16px Arial',
+        color: '#ffffff',
+      }),
+      p2: this.add.text(width - 170, infoY + 110, '', {
+        font: '16px Arial',
+        color: '#ffffff',
+      }),
+    };
+
     // track hits and round-score totals
     this.hits = { p1: 0, p2: 0 };
     this.score = { p1: 0, p2: 0 };
@@ -142,6 +153,7 @@ export class OverlayUI extends Phaser.Scene {
       this.hits = { p1: 0, p2: 0 };
       this.score = { p1: 0, p2: 0 };
       this.updateHitTexts();
+      this.setTitles('', '');
       if (this.enterHandler) {
         this.input.keyboard.off('keydown', this.enterHandler);
         this.enterHandler = null;
@@ -205,6 +217,7 @@ export class OverlayUI extends Phaser.Scene {
         this.locationText.setText(parts);
       }
     };
+    this.onSetTitles = ({ p1, p2 }) => this.setTitles(p1, p2);
 
     eventBus.on('timer-tick', this.onTimerTick);
     eventBus.on('round-started', this.onRoundStarted);
@@ -218,6 +231,7 @@ export class OverlayUI extends Phaser.Scene {
     eventBus.on('score-update', this.onScoreUpdate);
     eventBus.on('match-date', this.onMatchDate);
     eventBus.on('match-started', this.onMatchStarted);
+    eventBus.on('set-titles', this.onSetTitles);
 
     this.events.once(Phaser.Scenes.Events.SHUTDOWN, () => {
       eventBus.off('timer-tick', this.onTimerTick);
@@ -232,6 +246,7 @@ export class OverlayUI extends Phaser.Scene {
       eventBus.off('score-update', this.onScoreUpdate);
       eventBus.off('match-date', this.onMatchDate);
       eventBus.off('match-started', this.onMatchStarted);
+      eventBus.off('set-titles', this.onSetTitles);
     });
   }
 
@@ -269,6 +284,13 @@ export class OverlayUI extends Phaser.Scene {
     if (this.nameText) {
       this.nameText.p1.setText(p1);
       this.nameText.p2.setText(p2);
+    }
+  }
+
+  setTitles(p1, p2) {
+    if (this.titleText) {
+      this.titleText.p1.setText(p1);
+      this.titleText.p2.setText(p2);
     }
   }
 


### PR DESCRIPTION
## Summary
- Append each boxer's ranking beside their name in the calendar view
- Show boxer titles beneath hit statistics in matches using trophy markers

## Testing
- `node --check src/scripts/calendar-scene.js`
- `node --check src/scripts/overlay.js`
- `node --check src/scripts/match-scene.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689cef55d850832a990b3e60a85e0363