### PR TITLE
Fix purse display for AI matches and restrict ranking leaps

### DIFF
--- a/src/scripts/calendar-scene.js
+++ b/src/scripts/calendar-scene.js
@@ -7,6 +7,7 @@ import {
 } from './calendar.js';
 import { getPendingMatch, clearPendingMatch } from './next-match.js';
 import { getMatchLog } from './match-log.js';
+import { getMatchPreview } from './boxer-stats.js';
 import { SoundManager } from './sound-manager.js';
 import { formatMoney } from './helpers.js';
 
@@ -201,6 +202,10 @@ export class CalendarScene extends Phaser.Scene {
       this.scene.start('MatchIntroScene', matchData);
       return;
     }
+    const { purse, winnerBonus, titlesOnTheLine } = getMatchPreview(
+      match.boxer1,
+      match.boxer2
+    );
     const matchData = {
       ...match,
       red: match.boxer1,
@@ -209,6 +214,9 @@ export class CalendarScene extends Phaser.Scene {
       aiLevel2: 'default',
       matchIndex: index,
       returnScene: 'Calendar',
+      purse,
+      winnerBonus,
+      titlesOnTheLine,
     };
     this.scene.start('MatchIntroScene', matchData);
   }

--- a/src/scripts/calendar.js
+++ b/src/scripts/calendar.js
@@ -76,7 +76,21 @@ export function generateMonthlyMatches(excluded = []) {
   const matches = [];
   function addMatch(pool) {
     const boxer1 = pickRandom(pool);
-    const boxer2 = pickRandom(pool);
+    // Find opponents within 10 ranking steps
+    const candidates = [];
+    for (let i = 0; i < pool.length; i++) {
+      if (Math.abs(pool[i].ranking - boxer1.ranking) <= 10) {
+        candidates.push(i);
+      }
+    }
+    let boxer2;
+    if (candidates.length > 0) {
+      const idx = candidates[Math.floor(Math.random() * candidates.length)];
+      boxer2 = pool.splice(idx, 1)[0];
+    } else {
+      // Fallback to any opponent to avoid deadlocks
+      boxer2 = pickRandom(pool);
+    }
     exclude.add(boxer1.name);
     exclude.add(boxer2.name);
     matches.push({


### PR DESCRIPTION
## Summary
- Ensure purse and winner bonus show in MatchIntro when simulating AI-only bouts by computing match preview data
- Constrain monthly match generation so opponents are within ten ranking places, avoiding huge upward jumps

## Testing
- `node --check src/scripts/calendar-scene.js`
- `node --check src/scripts/calendar.js`
- `npm test` *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_689cf27343e0832a8a422b98be6df4ee