### PR TITLE
Add ranking numbers to names in MatchScene

### DIFF
--- a/src/scripts/match-scene.js
+++ b/src/scripts/match-scene.js
@@ -220,9 +220,13 @@ export class MatchScene extends Phaser.Scene {
       eventBus.off('next-round');
     });
 
+    const name1 = data?.boxer1?.name || '';
+    const name2 = data?.boxer2?.name || '';
+    const rank1 = data?.boxer1?.ranking;
+    const rank2 = data?.boxer2?.ranking;
     eventBus.emit('set-names', {
-      p1: data?.boxer1?.name || '',
-      p2: data?.boxer2?.name || '',
+      p1: rank1 != null ? name1 + ' (' + rank1 + ')' : name1,
+      p2: rank2 != null ? name2 + ' (' + rank2 + ')' : name2,
     });
     eventBus.emit('set-titles', {
       p1: (data?.boxer1?.titles || []).map((t) => `${t}🏆`).join(' '),


### PR DESCRIPTION
## Summary
- Display boxer ranking number in parentheses after their names in MatchScene

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689cf2e63184832a952e993742c5e414