### PR TITLE
Save full details for simulated matches and streamline options back button

### DIFF
--- a/src/scripts/options-scene.js
+++ b/src/scripts/options-scene.js
@@ -167,12 +167,9 @@ export class OptionsScene extends Phaser.Scene {
         this.scene.start('StartScene');
       }
     };
-    this.add
-      .text(20, H - 40, 'Back', { font: '24px Arial', color: '#ffff00' })
-      .setInteractive({ useHandCursor: true })
-      .on('pointerdown', back);
 
-    this.input.keyboard.on('keydown-ESC', back);    
+    makeLink('Back', panelX + panelW * 0.78, back);
+    this.input.keyboard.on('keydown-ESC', back);
 
     // Städa alla lyssnare vid shutdown (säkerhetsnät)
     this.events.once(Phaser.Scenes.Events.SHUTDOWN, () => {


### PR DESCRIPTION
## Summary
- Log complete match metadata for simulated bouts, including date, arena, ranks, method, round time and prize money.
- Select a random arena when generating monthly AI matches.
- Move the Options scene Back button next to Clear data and match its style with other controls.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689d9f1e7b60832abd5ec211461427e6