### PR TITLE
Fix calendar row rendering for completed matches

### DIFF
--- a/src/scripts/calendar-scene.js
+++ b/src/scripts/calendar-scene.js
@@ -151,6 +151,7 @@ export class CalendarScene extends Phaser.Scene {
             .setOrigin(0.5, 0)
         );
         this.rows.push(row);
+        rowIdx++;
         return;
       }
       row.push(


### PR DESCRIPTION
## Summary
- ensure calendar row index increments when match has a result

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689dccb2fb38832a8afea54c0ddf30a2