### PR TITLE
Show simulated match results

### DIFF
--- a/src/scripts/calendar-scene.js
+++ b/src/scripts/calendar-scene.js
@@ -244,6 +244,30 @@ export class CalendarScene extends Phaser.Scene {
   async simulate(match) {
     if (match.player) {
       await this.simulatePendingMatches();
+      await simulateMatch(match, 500);
+      const result = match.result || {};
+      const resultData = {
+        b1: {
+          name: match.boxer1.name,
+          prize: result.b1?.prize,
+          rankingBefore: result.b1?.rankingBefore,
+          rankingAfter: result.b1?.rankingAfter,
+        },
+        b2: {
+          name: match.boxer2.name,
+          prize: result.b2?.prize,
+          rankingBefore: result.b2?.rankingBefore,
+          rankingAfter: result.b2?.rankingAfter,
+        },
+        roundLog: result.rounds,
+        titlesWon: (result.titlesWon || []).map((code) => ({ code })),
+        matchIndex: this.playerIndex,
+        matchSummary: result,
+        returnScene: 'Ranking',
+      };
+      clearPendingMatch();
+      this.scene.start('GameResultScene', resultData);
+      return;
     }
     await simulateMatch(match, 500);
     this.render();

--- a/src/scripts/calendar.js
+++ b/src/scripts/calendar.js
@@ -198,6 +198,16 @@ export async function simulateMatch(match, delayMs = 1000) {
     rankingBefore: winner === match.boxer1 ? b1RankBefore : b2RankBefore,
     rankingAfter: winner.ranking,
     titlesWon,
+    b1: {
+      prize: prize1,
+      rankingBefore: b1RankBefore,
+      rankingAfter: match.boxer1.ranking,
+    },
+    b2: {
+      prize: prize2,
+      rankingBefore: b2RankBefore,
+      rankingAfter: match.boxer2.ranking,
+    },
   };
   return match.result;
 }

--- a/src/scripts/game-result-scene.js
+++ b/src/scripts/game-result-scene.js
@@ -30,13 +30,19 @@ export class GameResultScene extends Phaser.Scene {
       ? this.resultData.roundLog
       : [];
     let y = 80;
-    rounds.forEach((r) => {
-      const line = `Round ${r.round}: ${r.p1Score}-${r.p2Score} (${r.totalP1}-${r.totalP2})`;
-      this.add.text(width / 2, y, line, {
-        font: '24px Arial',
-        color: '#ffffff',
-      }).setOrigin(0.5);
-      y += 30;
+    rounds.forEach((r, i) => {
+      let line;
+      if (typeof r === 'string') {
+        line = r;
+      } else if (r && typeof r === 'object') {
+        line = `Round ${r.round}: ${r.p1Score}-${r.p2Score} (${r.totalP1}-${r.totalP2})`;
+      }
+      if (line) {
+        this.add
+          .text(width / 2, y, line, { font: '24px Arial', color: '#ffffff' })
+          .setOrigin(0.5);
+        y += 30;
+      }
     });
     y += 20;
 


### PR DESCRIPTION
## Summary
- Store both boxers' prizes and ranking changes when simulating matches
- Show GameResultScene after simulating player matches
- Allow GameResultScene to display simple round log strings

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/theboxer/package.json')*

------
https://chatgpt.com/codex/tasks/task_e_689dd5a10fb0832a893ab3e468ac7699