### PR TITLE
Add Spine plugin and minimal demo

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -29,7 +29,9 @@
     
     canvas { display: block; }
   </style>
-  <script src="https://cdn.jsdelivr.net/npm/phaser@3/dist/phaser.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/phaser@3/dist/phaser.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@esotericsoftware/spine-webgl@4.1.19/dist/iife/spine-webgl.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@esotericsoftware/spine-phaser@4.1.19/dist/iife/SpinePlugin.min.js"></script>
 </head>
 <body>
   <div id="game-container"></div>  

--- a/src/scripts/main.js
+++ b/src/scripts/main.js
@@ -11,5 +11,10 @@ new window.Phaser.Game({
     mode: window.Phaser.Scale.FIT,
     autoCenter: window.Phaser.Scale.CENTER_BOTH
   },
+  plugins: {
+    scene: [
+      { key: 'SpinePlugin', plugin: window.SpinePlugin, sceneKey: 'spine' }
+    ]
+  },
   scene: [BootScene]
 });

--- a/src/scripts/scenes/PreloadScene.js
+++ b/src/scripts/scenes/PreloadScene.js
@@ -4,14 +4,22 @@ export class PreloadScene extends window.Phaser.Scene {
   constructor() { super('Preload'); }
 
   preload() {
-    // Later: load only the Spine assets needed for the current match.
-    // Example (when runtime is added):
-    // this.load.text('boxer_skel', 'assets/spine/boxer/boxer_skeleton.json');
-    // this.load.text('boxer_atlas', 'assets/spine/boxer/boxer.atlas');
-    // this.load.image('boxer_tex', 'assets/spine/boxer/boxer.png');
+    // Exportera från Spine: boxer.skel + boxer.atlas (+ boxer.png via atlasen)
+    this.load.spineBinary('boxer-data', 'assets/spine/boxer/boxer.skel');
+    this.load.spineAtlas('boxer-atlas', 'assets/spine/boxer/boxer.atlas'); // PNG laddas automatiskt
   }
 
   create() {
+    // Skapa instans
+    const boxer = this.add.spine(400, 600, 'boxer-data', 'boxer-atlas');
+
+    // (valfritt) välj skin
+    boxer.skeleton.setSkinByName?.('boxerA');
+    boxer.skeleton.setSlotsToSetupPose?.();
+
+    // spela en animation
+    boxer.animationState.setAnimation(0, 'idle', true);
+
     this.scene.add('AnimTest', AnimTestScene, true);
     this.scene.remove('Preload');
   }


### PR DESCRIPTION
## Summary
- include Spine WebGL runtime and Phaser Spine plugin in index.html
- register Spine plugin in Phaser game config
- load Spine assets and display animated boxer in PreloadScene

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a0b03364c4832a9d374365b5fd004f