### PR TITLE
Fix SpinePlugin reference for Phaser

### DIFF
--- a/src/scripts/main.js
+++ b/src/scripts/main.js
@@ -18,7 +18,8 @@ new window.Phaser.Game({
       // as `this.spine` instead of using the invalid "sceneKey" field, which caused
       // Phaser to report "Missing plugin for key: SpinePlugin" and left loader methods
       // like `this.load.spineBinary` undefined.
-      { key: 'SpinePlugin', plugin: window.SpinePlugin, mapping: 'spine' }
+      // The global `spine-phaser-v3` script exposes the plugin on `window.spinephaser`.
+      { key: 'SpinePlugin', plugin: window.spinephaser.SpinePlugin, mapping: 'spine' }
     ]
   },
   scene: [BootScene]


### PR DESCRIPTION
## Summary
- reference Spine plugin via `window.spinephaser` so Phaser can load it

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a0c117e0cc832a8dc7ff5b8cf26d27